### PR TITLE
RVL: Allow CDMusic volume to be modified in the settings menu

### DIFF
--- a/source/wii/cdaudio.c
+++ b/source/wii/cdaudio.c
@@ -46,7 +46,6 @@ void CDAudio_PlayFromString(char* track_name, qboolean looping)
 		return;
 	}
 	
-	MP3Player_Volume(255);	
 	MP3Player_PlayBuffer (mp3buffer, com_filesize, NULL);
 	
 	isplaying = true;
@@ -56,8 +55,7 @@ void CDAudio_PlayFromString(char* track_name, qboolean looping)
 
 void CDAudio_Stop(void)
 {
-	MP3Player_Stop();
-	free (mp3buffer);
+	stopmp3 = true;
 }
 
 
@@ -75,13 +73,14 @@ void CDAudio_Update(void)
 	isplaying = MP3Player_IsPlaying ();
 	
 	if (isplaying == true) {
-		free(mp3buffer);
-		stopmp3 = true;
+		MP3Player_Volume(bgmvolume.value * 255);
 	}
 	
 	if (stopmp3 == true) {
 		if (mp3buffer) {
+			MP3Player_Stop();
 			free (mp3buffer);
+			isplaying = false;
 		}
 	}
 	

--- a/source/wii/main.c
+++ b/source/wii/main.c
@@ -247,14 +247,13 @@ int main(int argc, char* argv[])
 		Host_Frame(current_time - last_time);
 		last_time = current_time;
 		
-		//Con_Printf ("time: %f \n", current_time_millisec);
-		//Con_Printf ("time off: %f \n", time_wpad_off_millisec);
-		
 		if (rumble_on&&(current_time > time_wpad_off)) 
 		{
 			WPAD_Rumble(0, false);
 			rumble_on = 0;
 		}
+		
+		CDAudio_Update();
 	};
 
 	exit(0);


### PR DESCRIPTION
### Description of Changes
---
Changes CDAudio logic to allow volume to be manipulated in the settings menu. 

### Visual Sample
---
N/A

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
