### PR TITLE
PR: Add PSP-1000 support to Vril tests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,8 +72,9 @@ jobs:
         with:
           name: rvl-nzp-dol
           path: ./build/wii/apps/nzportable/boot.dol
-  Pull-Request-Test-PSP:
+  Pull-Request-Test-PSP1000:
     if: github.event_name == 'pull_request'
+    name: PSP-1000 Pull Request Tests
     runs-on: ubuntu-latest
     container:
       image: ubuntu:24.10
@@ -89,10 +90,32 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /
-      - name: Run PlayStation Portable Pull Request Tests
+      - name: Run All
         run: |
           cd ./testing
-          ./run_tests.sh --platform psp --test all --content "$(pwd)/validate"
+          ./run_tests.sh --platform psp --test all --content "$(pwd)/validate" --mode fat
+  Pull-Request-Test-PSP2000:
+    if: github.event_name == 'pull_request'
+    name: PSP-2000 Pull Request Tests
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.10
+      options: --shm-size=8192m
+    needs: [Compile-EBOOT, Compile-3DSX, Compile-DOL]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Wait for GitHub to keep up..
+        run: sleep 2s
+        shell: bash
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /
+      - name: Run All
+        run: |
+          cd ./testing
+          ./run_tests.sh --platform psp --test all --content "$(pwd)/validate" --mode slim
   Unify-and-Release:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -23,6 +23,7 @@ function print_help()
     echo "-p (--platform) : Platform to run tests for. Looks in setup directory."
     echo "-t (--test)     : Test to run. Use \"all\" to run all tests. Looks in tests directory."
     echo "-g (--generate) : Generates master bitmaps of all maps to compare against."
+    echo "-m (--mode)     : Extra mode flag to pass into test scripts."
     echo "-h (--help)     : Displays this message."
 }
 
@@ -32,6 +33,7 @@ while true; do
         -t | --test ) TEST="$2"; shift 2 ;;
         -g | --generate ) TEST="generate-source"; shift 1 ;;
         -c | --content ) CONTENT_DIR="$2"; shift 2 ;;
+        -m | --mode ) MODE="$2"; shift 2 ;;
         -h | --help ) print_help; exit 0 ;;
         -- ) shift; break ;;
         * ) break ;;
@@ -93,12 +95,12 @@ function run_test()
                 continue
             fi
 
-            local cmd="source ./tests/${pretty_sh}.sh ${PLATFORM} ${CONTENT_DIR}"
+            local cmd="source ./tests/${pretty_sh}.sh ${PLATFORM} ${CONTENT_DIR} ${MODE}"
             $cmd
         done
     else
         echo "$(pwd)"
-        local cmd="source ./tests/${TEST}.sh ${PLATFORM} ${CONTENT_DIR}"
+        local cmd="source ./tests/${TEST}.sh ${PLATFORM} ${CONTENT_DIR} ${MODE}"
 
         $cmd
     fi
@@ -114,7 +116,7 @@ function main()
     # Begin prepping our environment.
     local dir=$(pwd)
     load_setup_script;
-    begin_setup;
+    begin_setup "${dir}";
     cd "${dir}"
 
     # Run our tests.

--- a/testing/setup/psp.sh
+++ b/testing/setup/psp.sh
@@ -22,6 +22,8 @@ TIMEOUT=30
 # The PPSSPP branch we checkout and use.
 ppsspp_version="v1.17.1"
 
+testing_dir_path=""
+
 # tzdata will try to display an interactive install prompt by
 # default, so make sure we define our system as non-interactive.
 export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
@@ -46,8 +48,13 @@ function clone_ppsspp
 
 function build_ppsspp
 {
+    cd /working/
+    print_info "Patching PPSSPP.."
+    local command="patch -p0 ppsspp/headless/Headless.cpp ${testing_dir_path}/setup/utils/ppsspp.patch"
+    echo "[${command}]"
+    $command
     print_info "Building PPSSPP.."
-    local command="./b.sh --headless"
+    command="./b.sh --headless"
     echo "[${command}]"
     cd /working/ppsspp
     ${command}
@@ -71,6 +78,8 @@ function obtain_nzportable
 
 function begin_setup()
 {
+    testing_dir_path="${1}"
+
     # Create our working directory.
     rm -rf /working
     mkdir -p /working/assets
@@ -96,10 +105,15 @@ function run_nzportable()
 {
     local mode="$1"
     local comp="$2"
+    local system="$3"
+
+    if [[ "${system}" == "" ]]; then
+        system="slim"
+    fi
 
     if [[ "${mode}" == "1" ]]; then
-        echo "/working/${EMULATOR_BIN} --screenshot=${comp} --timeout=${TIMEOUT} -r /working/nzportable/ /working/nzportable/EBOOT.PBP"
+        echo "/working/${EMULATOR_BIN} --system=${system} --screenshot=${comp} --timeout=${TIMEOUT} -r /working/nzportable/ /working/nzportable/EBOOT.PBP"
     else
-        echo "/working/${EMULATOR_BIN} --timeout=${TIMEOUT} -r /working/nzportable/ /working/nzportable/EBOOT.PBP"
+        echo "/working/${EMULATOR_BIN} --system=${system} --timeout=${TIMEOUT} -r /working/nzportable/ /working/nzportable/EBOOT.PBP"
     fi
 }

--- a/testing/setup/utils/ppsspp.patch
+++ b/testing/setup/utils/ppsspp.patch
@@ -1,0 +1,45 @@
+--- ppsspp/headless/Headless.cpp	2025-03-15 08:18:43
++++ ppsspp_patch/headless/Headless.cpp	2025-03-15 08:20:35
+@@ -162,6 +162,8 @@
+ 
+ 	fprintf(stderr, "  --graphics=BACKEND    use a different gpu backend\n");
+ 	fprintf(stderr, "                        options: gles, software, directx9, etc.\n");
++	fprintf(stderr, "  --system=MODEL		 use specified system model\n");
++	fprintf(stderr, "					     options: fat, slim (default)\n");
+ 	fprintf(stderr, "  --screenshot=FILE     compare against a screenshot\n");
+ 	fprintf(stderr, "  --max-mse=NUMBER      maximum allowed MSE error for screenshot\n");
+ 	fprintf(stderr, "  --timeout=SECONDS     abort test it if takes longer than SECONDS\n");
+@@ -338,6 +340,7 @@
+ 	GPUCore gpuCore = GPUCORE_SOFTWARE;
+ 	CPUCore cpuCore = CPUCore::JIT;
+ 	int debuggerPort = -1;
++	int systemModel = PSP_MODEL_SLIM;
+ 
+ 	std::vector<std::string> testFilenames;
+ 	const char *mountIso = nullptr;
+@@ -391,6 +394,16 @@
+ 			else
+ 				return printUsage(argv[0], "Unknown gpu backend specified after --graphics=. Allowed: software, directx9, directx11, vulkan, gles, null.");
+ 		}
++		else if (!strncmp(argv[i], "--system=", strlen("--system=")) && strlen(argv[i]) > strlen("--system="))
++		{
++			const char *systemName = argv[i] + strlen("--system=");
++			if (!strcasecmp(systemName, "fat"))
++				systemModel = PSP_MODEL_FAT;
++			else if (!strcasecmp(systemName, "slim"))
++				systemModel = PSP_MODEL_SLIM;
++			else
++				return printUsage(argv[0], "Unknown system model specified after --system=. Allowed: fat, slim.");
++		}
+ 		// Default to GLES if no value selected.
+ 		else if (!strcmp(argv[i], "--graphics")) {
+ #if PPSSPP_API(ANY_GL)
+@@ -493,7 +506,7 @@
+ 	g_Config.bEnableWlan = true;
+ 	g_Config.sMACAddress = "12:34:56:78:9A:BC";
+ 	g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
+-	g_Config.iPSPModel = PSP_MODEL_SLIM;
++	g_Config.iPSPModel = systemModel;
+ 	g_Config.iGlobalVolume = VOLUME_FULL;
+ 	g_Config.iReverbVolume = VOLUME_FULL;
+ 	g_Config.internalDataDirectory.clear();

--- a/testing/tests/map-boot.sh
+++ b/testing/tests/map-boot.sh
@@ -15,6 +15,7 @@ set -o errexit
 
 PLATFORM="$1"
 CONTENT_DIR="$2"
+MODE="$3"
 
 source "setup/${PLATFORM}.sh"
 
@@ -46,7 +47,7 @@ function run_mapboot_test()
 
         # Load emulator and attempt to boot map
         print_info "Loading Nazi Zombies: Portable via [${EMULATOR_BIN}] with map [${pretty_bsp}].."
-        local command=$(run_nzportable "1" "${CONTENT_DIR}/${PLATFORM}/${pretty_bsp}.bmp")
+        local command=$(run_nzportable "1" "${CONTENT_DIR}/${PLATFORM}/${pretty_bsp}.bmp" "${MODE}")
         echo "[${command}]"
         ${command} > /dev/null 2>&1 || emulator_failed="1"
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Creates a patch for PPSSPP that we apply after cloning that allows us to test simulating a PSP-1000 unit, and creates an additional job to use this flag so we test both low mem and high mem PSP models.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
