### PR TITLE
GLOBAL: BUILD: Add fanalyzer option to Makefiles

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -36,6 +36,10 @@ ifeq ($(WERROR),1)
 CFLAGS 		+= -Werror
 endif
 
+ifeq ($(FANALYZER),1)
+CFLAGS		+= -fanalyzer
+endif
+
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
 ASFLAGS	:=	-g $(ARCH)

--- a/Makefile.psp
+++ b/Makefile.psp
@@ -124,6 +124,10 @@ ifeq ($(WERROR),1)
 CFLAGS 		+= -Werror
 endif
 
+ifeq ($(FANALYZER),1)
+CFLAGS		+= -fanalyzer
+endif
+
 CXXFLAGS = -fno-rtti -Wcast-qual -Wno-write-strings -Wno-sign-compare -Wno-strict-aliasing
 ASFLAGS = $(CFLAGS) -c
 

--- a/Makefile.rvl
+++ b/Makefile.rvl
@@ -37,6 +37,10 @@ ifeq ($(WERROR),1)
 CFLAGS 		+= -Werror
 endif
 
+ifeq ($(FANALYZER),1)
+CFLAGS		+= -fanalyzer
+endif
+
 CXXFLAGS = $(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map


### PR DESCRIPTION
To run a build with the GCC static analyzer, use a command like:

make -f Makefile.ctr FANALYZER=1

### Description of Changes
Add a new variable to check to enable -fanalyzer when running builds.

### Visual Sample
---
```
$ make -f Makefile.ctr FANALYZER=1
test_handler.c
chase.c
...
C:/msys64/home/peter/vril-engine/source/wad.c: In function 'ConvertWad3ToRGBA':
C:/msys64/home/peter/vril-engine/source/wad.c:262:28: warning: dereference of possibly-NULL 'data' [CWE-690] [-Wanalyzer-possible-null-dereference]
  262 |          ((int *) data)[i] = 0;
      |          ~~~~~~~~~~~~~~~~~~^~~
  'ConvertWad3ToRGBA': events 1-6
    |
    |  256 |    data = malloc(image_size * 4); // Baker
    |      |           ^~~~~~~~~~~~~~~~~~~~~~
    |      |           |
    |      |           (1) this call could return NULL
    |......
    |  259 |    for (i = 0; i < image_size; i++) {
    |      |                ~~~~~~~~~~~~~~
    |      |                  |
    |      |                  (2) following 'true' branch (when 'i < image_size')...
    |  260 |       p = *in++;
    |      |            ~~~~
    |      |              |
    |      |              (3) ...to here
    |  261 |       if (tex->name[0] == '{' && p == 255) {
    |      |          ~
    |      |          |
    |      |          (4) following 'true' branch...
    |  262 |          ((int *) data)[i] = 0;
    |      |          ~~~~~~~~~~~~~~~~~~~~~
    |      |                        |   |
    |      |                        |   (6) 'data + (unsigned int)i * 4' could be NULL: unchecked value from (1)
    |      |                        (5) ...to here
    |
```

### Checklist
---
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage