### PR TITLE
3DS: Fix many warnings, compile with -Wdouble-promotion

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -26,7 +26,7 @@ APP_DESCRIPTION := Call of Duty Zombies remake
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -fpermissive -Wall -O3 -mword-relocations \
+CFLAGS	:=	-g -Wall -Wdouble-promotion -O3 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 

--- a/source/chase.c
+++ b/source/chase.c
@@ -171,9 +171,9 @@ void Chase_Update (void)
       dist = 1;
 
    #ifdef PSP_VFPU
-   r_refdef.viewangles[PITCH] = -vfpu_atanf(stop[2] / dist) / M_PI * 180;
+   r_refdef.viewangles[PITCH] = -vfpu_atanf(stop[2] / dist) * ((float)M_PI / 180.0f);
    #else
-   r_refdef.viewangles[PITCH] = -atan(stop[2] / dist) / M_PI * 180;
+   r_refdef.viewangles[PITCH] = -atanf(stop[2] / dist) * ((float)M_PI / 180.0f);
    #endif
 
    // move towards destination

--- a/source/cl_demo.c
+++ b/source/cl_demo.c
@@ -195,7 +195,7 @@ record <demoname> <map> [cd track]
 void CL_Record_f (void)
 {
 	int		c;
-	char	name[MAX_OSPATH];
+	char	name[MAX_OSPATH+1];
 	int		track;
 	char	forcetrack[16];
 
@@ -229,8 +229,10 @@ void CL_Record_f (void)
 	}
 	else
 		track = -1;	
-
-	snprintf (name, MAX_OSPATH + 1, "%s/%s", com_gamedir, Cmd_Argv(1));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+	snprintf (name, MAX_OSPATH, "%s/%s", com_gamedir, Cmd_Argv(1));
+#pragma GCC diagnostic pop
 	
 //
 // start the map up
@@ -344,7 +346,7 @@ void CL_FinishTimeDemo (void)
 	
 // the first frame didn't count
 	frames = (host_framecount - cls.td_startframe) - 1;
-	time = realtime - cls.td_starttime;
+	time = realtime - (double)cls.td_starttime;
 	if (time < 1)
 		time = 1;
 	Con_Printf ("%i frames %5.1f seconds %5.1f fps\n", frames, time, frames/time);

--- a/source/cl_hud.c
+++ b/source/cl_hud.c
@@ -280,8 +280,8 @@ void HUD_NewMap (void)
 	point_change_interval = 0;
 	point_change_interval_neg = 0;
 
-	round_center_x = (vid.width - sb_round[0]->width) /2;
-	round_center_y = (vid.height - sb_round[0]->height) /2;
+	round_center_x = (vid.width - sb_round[0]->width) / 2.0f;
+	round_center_y = (vid.height - sb_round[0]->height) / 2.0f;
 	
 	bettyprompt_time = 0;
 	nameprint_time = 0;
@@ -310,8 +310,7 @@ int HUD_itoa (int num, char *buf)
 		num = -num;
 	}
 
-	for (pow10 = 10 ; num >= pow10 ; pow10 *= 10)
-	;
+	for (pow10 = 10 ; num >= pow10 ; pow10 *= 10);
 
 	do
 	{
@@ -477,10 +476,10 @@ void HUD_Parse_Point_Change (int points, int negative, int x_start, int y_start)
 	point_change[i].negative = negative;
 
 	f = HUD_itoa (points, str);
-	point_change[i].x = x_start + (10.0 + 8.0*f * hud_scale_factor);
+	point_change[i].x = x_start + (10.0f + 8.0f*f * hud_scale_factor);
 	point_change[i].y = y_start;
-	point_change[i].move_x = (1.0 * hud_scale_factor);
-	point_change[i].move_y = ((rand ()&0x7fff) / ((float)0x7fff)) - (0.5 * hud_scale_factor);
+	point_change[i].move_x = (1.0f * hud_scale_factor);
+	point_change[i].move_y = ((rand ()&RAND_MAX) / ((float)RAND_MAX)) - (0.5f * hud_scale_factor);
 
 	point_change[i].alive_time = Sys_FloatTime() + 0.4;
 }
@@ -609,9 +608,9 @@ void HUD_Blood (void)
 	//this function scales linearly from health = 0 to health = 100
 	//alpha = (100.0 - (float)cl.stats[STAT_HEALTH])/100*255;
 	//but we want the picture to be fully visible at health = 20, so use this function instead
-	alpha = (100.0 - ((1.25 * (float) cl.stats[STAT_HEALTH]) - 25))/100*255;
+	alpha = (100.0f - ((1.25f * cl.stats[STAT_HEALTH]) - 25))/100*255;
 	
-	if (alpha <= 0.0)
+	if (alpha <= 0.0f)
 		return;
     
 #ifdef PSP_VFPU
@@ -620,14 +619,14 @@ void HUD_Blood (void)
 	float modifier = (sin(cl.time * 10) * 20) - 20;//always negative
 #endif // PSP_VFPU
 
-	if(modifier < -35.0)
-		modifier = -35.0;
+	if(modifier < -35.0f)
+		modifier = -35.0f;
     
 	alpha += modifier;
     
-	if(alpha < 0.0)
+	if(alpha < 0.0f)
 		return;
-	float color = 255.0 + modifier;
+	float color = 255.0f + modifier;
     
 	Draw_ColoredStretchPic(0, 0, fx_blood_lu, vid.width, vid.height, color, color, color, alpha);
 }
@@ -680,19 +679,19 @@ void HUD_WorldText(int alpha)
 		if (!strcmp("chaptertitle", key)) // search for chaptertitle key
 		{
 			has_chaptertitle = true;
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (10 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);	
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (10 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);	
 		}
 		if (!strcmp("location", key)) // search for location key
 		{
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (20 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (20 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
 		}
 		if (!strcmp("date", key)) // search for date key
 		{
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (30 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (30 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
 		}
 		if (!strcmp("person", key)) // search for person key
 		{
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (40 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (40 * hud_scale_factor), value, 255, 255, 255, alpha, hud_scale_factor);
 		}
 	}
 }
@@ -795,7 +794,7 @@ void HUD_Rounds (void)
 		HUD_WorldText(value2);
 		
 		if (has_chaptertitle == false)
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, value2, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, value2, hud_scale_factor);
 		
 		value -= cl.time * 0.4;
 		value2 += cl.time * 0.4;
@@ -811,7 +810,7 @@ void HUD_Rounds (void)
 		HUD_WorldText(255);
 		
 		if (has_chaptertitle == false)
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, 255, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, 255, hud_scale_factor);
 
 		value2 += cl.time * 0.4;
 
@@ -825,7 +824,7 @@ void HUD_Rounds (void)
 		HUD_WorldText(value2);
 		
 		if (has_chaptertitle == false)
-			Draw_ColoredString(6 * hud_scale_factor, vid.height/2 + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, value2, hud_scale_factor);
+			Draw_ColoredString(6 * hud_scale_factor, vid.height/2.0f + (10 * hud_scale_factor), "'Nazi Zombies'", 255, 255, 255, value2, hud_scale_factor);
 
 		value2 -= cl.time * 0.4;
 
@@ -860,8 +859,8 @@ void HUD_Rounds (void)
 	{
 		Draw_ColoredStretchPic(round_center_x, round_center_y, sb_round[0], 
 		sb_round[0]->width * hud_scale_factor, sb_round[0]->height * hud_scale_factor, 107, 1, 0, 255);
-		round_center_x = round_center_x - (229/108) - (0.2 * hud_scale_factor);
-		round_center_y = round_center_y + (0.95 * hud_scale_factor); // don't move y too quickly
+		round_center_x = round_center_x - (229.0f/108.0f) - (0.2f * hud_scale_factor);
+		round_center_y = round_center_y + (0.95f * hud_scale_factor); // don't move y too quickly
 		if (round_center_x <= 5 * hud_scale_factor)
 			round_center_x = 5 * hud_scale_factor;
 		if (round_center_y >= vid.height - (sb_round[0]->height * hud_scale_factor) - 2)
@@ -948,7 +947,7 @@ void HUD_Rounds (void)
 	}
 	else if (cl.stats[STAT_ROUNDCHANGE] == 4)//blink white
 	{
-		if (endroundchange > cl.time) {
+		if (endroundchange > (float)cl.time) {
 			blinking = (((int)(realtime*475)&510) - 255);
 			blinking = abs(blinking);
 		} else {
@@ -1385,13 +1384,13 @@ void HUD_Powerups (void)
 
 	// both are avail draw fixed order
 	if (count == 2) {
-		Draw_StretchPic((vid.width/2) - (27 * hud_scale_factor), vid.height - (29 * hud_scale_factor), x2pic, scale, scale);
-		Draw_StretchPic((vid.width/2) + (3 * hud_scale_factor), vid.height - (29 * hud_scale_factor), instapic, scale, scale);
+		Draw_StretchPic((vid.width/2.0f) - (27 * hud_scale_factor), vid.height - (29 * hud_scale_factor), x2pic, scale, scale);
+		Draw_StretchPic((vid.width/2.0f) + (3 * hud_scale_factor), vid.height - (29 * hud_scale_factor), instapic, scale, scale);
 	} else {
 		if (cl.stats[STAT_X2])
-			Draw_StretchPic((vid.width/2) - (13 * hud_scale_factor), vid.height - (29 * hud_scale_factor), x2pic, scale, scale);
+			Draw_StretchPic((vid.width/2.0f) - (13 * hud_scale_factor), vid.height - (29 * hud_scale_factor), x2pic, scale, scale);
 		if(cl.stats[STAT_INSTA])
-			Draw_StretchPic ((vid.width/2) - (13 * hud_scale_factor), vid.height - (29 * hud_scale_factor), instapic, scale, scale);
+			Draw_StretchPic ((vid.width/2.0f) - (13 * hud_scale_factor), vid.height - (29 * hud_scale_factor), instapic, scale, scale);
 	}
 }
 
@@ -1437,7 +1436,7 @@ void HUD_Achievement (void)
 
 	if (achievement_unlocked == 1)
 	{
-		smallsec = smallsec + 0.7;
+		smallsec = smallsec + 0.7f;
 		if (smallsec >= 55)
 			smallsec = 55;
 		//Background image

--- a/source/cl_input.c
+++ b/source/cl_input.c
@@ -306,7 +306,7 @@ void CL_AdjustAngles (void)
 	float	cl_sensitivity;
 
 	if (in_speed.state & 1)
-		speed = host_frametime * cl_anglespeedkey.value;
+		speed = (float)host_frametime * cl_anglespeedkey.value;
 	else
 		speed = host_frametime;
 
@@ -319,13 +319,13 @@ void CL_AdjustAngles (void)
 	// cut look speed in half when facing enemy, unless
 	// mag is empty
 	if ((in_aimassist.value) && (sv_player->v.facingenemy == 1) && cl.stats[STAT_CURRENTMAG] > 0) {
-		speed *= 0.5;
+		speed *= 0.5f;
 	}
 	// additionally, slice look speed when ADS/scopes
 	if (cl.stats[STAT_ZOOM] == 1)
-		speed *= 0.5;
+		speed *= 0.5f;
 	else if (cl.stats[STAT_ZOOM] == 2)
-		speed *= 0.25;
+		speed *= 0.25f;
 	
 #ifdef __PSP__
 	cl_sensitivity = in_sensitivity.value;
@@ -395,12 +395,12 @@ void CL_BaseMove (usercmd_t *cmd)
 	cl_backspeed = cl_forwardspeed = cl_sidespeed = sv_player->v.maxspeed;
 
 	// Throttle side and back speeds
-	cl_sidespeed *= 0.8;
-	cl_backspeed *= 0.7;
+	cl_sidespeed *= 0.8f;
+	cl_backspeed *= 0.7f;
 	
 	if (waypoint_mode.value)
-		cl_backspeed = cl_forwardspeed = cl_sidespeed *= 1.5;
-		
+		cl_backspeed = cl_forwardspeed = cl_sidespeed *= 1.5f;
+			
 	if (in_strafe.state & 1)
 	{
 		cmd->sidemove += cl_sidespeed * CL_KeyState (&in_right);
@@ -459,7 +459,7 @@ int infront(edict_t *ent1, edict_t *ent2)
 	AngleVectors(temp_angle,temp_forward,temp_right,temp_up);
 
 	dot = DotProduct(vec,temp_forward);
-	if(dot > 0.98)
+	if(dot > 0.98f)
 	{
 		return 1;
 	}
@@ -514,7 +514,7 @@ void CL_Aim_Snap(void)
 
 	if (cl.perks & 64)
     	znum = EN_Find(0,"ai_zombie_head");
-  	else
+	else
     	znum = EN_Find(0,"ai_zombie");
 
 	z = EDICT_NUM(znum);

--- a/source/cl_main.c
+++ b/source/cl_main.c
@@ -295,7 +295,11 @@ void CL_PrintEntities_f (void)
 			continue;
 		}
 		Con_Printf ("%s:%2i  (%5.1f,%5.1f,%5.1f) [%5.1f %5.1f %5.1f]\n"
-		,ent->model->name,ent->frame, ent->origin[0], ent->origin[1], ent->origin[2], ent->angles[0], ent->angles[1], ent->angles[2]);
+		,ent->model->name,ent->frame,
+		(double)ent->origin[0], (double)ent->origin[1], (double)ent->origin[2],
+		(double)ent->angles[0],
+		(double)ent->angles[1],
+		(double)ent->angles[2]);
 	}
 }
 
@@ -411,7 +415,7 @@ dlight_t *CL_AllocDlight (int key)
 	dl = cl_dlights;
 	for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
 	{
-		if (dl->die < cl.time)
+		if (dl->die < (float)cl.time)
 		{
 			memset (dl, 0, sizeof(*dl));
 			dl->key = key;
@@ -434,7 +438,7 @@ void CL_NewDlight (int key, vec3_t origin, float radius, float time, int type)
 	dl = CL_AllocDlight (key);
 	VectorCopy (origin, dl->origin);
 	dl->radius = radius;
-	dl->die = cl.time + time;
+	dl->die = (float)cl.time + time;
 	dl->type = type;
 
 }
@@ -456,7 +460,7 @@ void CL_DecayLights (void)
 	dl = cl_dlights;
 	for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
 	{
-		if (dl->die < cl.time || !dl->radius)
+		if (dl->die < (float)cl.time || !dl->radius)
 			continue;
 
 		dl->radius -= time*dl->decay;
@@ -486,28 +490,28 @@ float CL_LerpPoint (void)
 		return 1;
 	}
 
-	if (f > 0.1)
+	if (f > 0.1f)
 	{	// dropped packet, or start of demo
 		cl.mtime[1] = cl.mtime[0] - 0.1;
-		f = 0.1;
+		f = 0.1f;
 	}
 
-	frac = (cl.ctime - cl.mtime[1]) / f;
+	frac = (float)(cl.ctime - cl.mtime[1]) / f;
 	if (frac < 0)
 	{
-		if (frac < -0.01)
+		if (frac < -0.01f)
 		{
 			cl.ctime = cl.time = cl.mtime[1];
 		}
-		frac = 0;
+		frac = 0.0f;
 	}
 	else if (frac > 1)
 	{
-		if (frac > 1.01)
+		if (frac > 1.01f)
 		{
 			cl.ctime = cl.time = cl.mtime[0];
 		}
-		frac = 1;
+		frac = 1/-f;
 	}
 
 	return frac;
@@ -523,7 +527,7 @@ vec3_t 	mdlflag_poweruprotate_startangles;
 vec3_t 	mdlflag_poweruprotate_differenceangles;
 vec3_t 	mdlflag_poweruprotate_currentangles;
 
-double 	last_puframetime = 0.0f;
+double 	last_puframetime = 0.0;
 
 /*
 ===============
@@ -535,9 +539,9 @@ void CL_UpdatePowerUpAngles (void)
 	// Don't update more than once per frame.
 	if (last_puframetime != host_frametime) {
 		// New cycle, dictate new rotation time and target angle. 
-		if (mdlflag_poweruprotate_duration <= cl.time) {
+		if (mdlflag_poweruprotate_duration <= (float)cl.time) {
 			mdlflag_poweruprotate_starttime = cl.time;
-			mdlflag_poweruprotate_duration = cl.time + (float)((rand() % 25 + 25)/10.0f); // Take between 2.5 and 5 seconds.
+			mdlflag_poweruprotate_duration = (float)cl.time + (float)((rand() % 25 + 25)/10.0f); // Take between 2.5 and 5 seconds.
 
 			mdlflag_poweruprotate_startangles[0] = mdlflag_poweruprotate_currentangles[0];
 			mdlflag_poweruprotate_startangles[1] = mdlflag_poweruprotate_currentangles[1];
@@ -557,11 +561,11 @@ void CL_UpdatePowerUpAngles (void)
 				if (mdlflag_poweruprotate_currentangles[i] > target_angles[i])
 					mdlflag_poweruprotate_differenceangles[i] = (mdlflag_poweruprotate_currentangles[i] - target_angles[i]) * -1;
 				else
-					mdlflag_poweruprotate_differenceangles[i] = fabs(mdlflag_poweruprotate_currentangles[i] - target_angles[i]);
+					mdlflag_poweruprotate_differenceangles[i] = fabsf(mdlflag_poweruprotate_currentangles[i] - target_angles[i]);
 			}
 		}
 
-		float percentage_complete = (cl.time - mdlflag_poweruprotate_starttime) / (mdlflag_poweruprotate_duration - mdlflag_poweruprotate_starttime);
+		float percentage_complete = ((float)cl.time - mdlflag_poweruprotate_starttime) / (mdlflag_poweruprotate_duration - mdlflag_poweruprotate_starttime);
 
 		for(int j = 0; j < 2; j++) {
 			mdlflag_poweruprotate_currentangles[j] = mdlflag_poweruprotate_startangles[j] + (mdlflag_poweruprotate_differenceangles[j] * percentage_complete);
@@ -977,9 +981,9 @@ int CL_ReadFromServer (void)
 		//{
 			//Con_Printf("++++++++++++++Got a new server message!+++++++++\n");
 		//}
-			cl.last_received_message = realtime;
+		cl.last_received_message = realtime;
 			//Con_Printf("ParseServerMessage \n");
-			CL_ParseServerMessage ();
+		CL_ParseServerMessage ();
 		//}
 
 	} while (ret && cls.state == ca_connected);
@@ -1017,8 +1021,8 @@ void CL_SendCmd (void)
 		CL_BaseMove (&cmd);
 
 	// allow mice or other external controllers to add to the move
-	if (!in_disable_analog.value)
-		IN_Move (&cmd);
+		if (!in_disable_analog.value)
+			IN_Move (&cmd);
 
 	// send the unreliable message
 		CL_SendMove (&cmd);

--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -126,12 +126,12 @@ void CL_ParseStartSoundPacket(void)
 
     field_mask = MSG_ReadByte();
 
-    if (field_mask & SND_VOLUME)
+	if (field_mask & SND_VOLUME)
 		volume = MSG_ReadByte ();
 	else
 		volume = DEFAULT_SOUND_PACKET_VOLUME;
 
-    if (field_mask & SND_ATTENUATION)
+	if (field_mask & SND_ATTENUATION)
 		attenuation = MSG_ReadByte () / 64.0;
 	else
 		attenuation = DEFAULT_SOUND_PACKET_ATTENUATION;
@@ -608,7 +608,7 @@ void CL_ParseUpdate (int bits)
 // Tomaz - QC Alpha Scale Glow Begin
 	if (bits & U_RENDERAMT)
 	    ent->renderamt = MSG_ReadFloat();
-    else
+	else
 	    ent->renderamt = 0;
 
     if (bits & U_RENDERMODE)
@@ -618,17 +618,17 @@ void CL_ParseUpdate (int bits)
 
 	if (bits & U_RENDERCOLOR1)
 	    ent->rendercolor[0] = MSG_ReadFloat();
-    else
+	else
 	    ent->rendercolor[0] = 0;
 
 	if (bits & U_RENDERCOLOR2)
 	    ent->rendercolor[1] = MSG_ReadFloat();
-    else
+	else
 	    ent->rendercolor[1] = 0;
 
 	if (bits & U_RENDERCOLOR3)
 	    ent->rendercolor[2] = MSG_ReadFloat();
-    else
+	else
 	    ent->rendercolor[2] = 0;
 // Tomaz - QC Alpha Scale Glow End
 
@@ -1167,7 +1167,7 @@ void CL_ParseServerMessage (void)
 
 		case svc_time:
 			cl.mtime[1] = cl.mtime[0];
-			cl.mtime[0] = MSG_ReadFloat ();
+			cl.mtime[0] = (double)MSG_ReadFloat ();
 			break;
 
 		case svc_clientdata:

--- a/source/cl_tent.c
+++ b/source/cl_tent.c
@@ -99,7 +99,7 @@ void CL_ParseBeam (model_t *m)
 // find a free beam
 	for (i=0, b=cl_beams ; i< MAX_BEAMS ; i++, b++)
 	{
-		if (!b->model || b->endtime < cl.time)
+		if (!b->model || b->endtime < (float)cl.time)
 		{
 			b->entity = ent;
 			b->model = m;
@@ -406,7 +406,7 @@ void CL_UpdateTEnts (void)
 // update lightning
 	for (i=0, b=cl_beams ; i< MAX_BEAMS ; i++, b++)
 	{
-		if (!b->model || b->endtime < cl.time)
+		if (!b->model || b->endtime < (float)cl.time)
 			continue;
 
 		// if coming from the player, update the start position
@@ -473,12 +473,12 @@ void CL_UpdateTEnts (void)
 		}
 		else
 		{
-			yaw = (int) (atan2f(dist[1], dist[0]) * 180 / M_PI);
+			yaw = (int) (atan2f(dist[1], dist[0]) * (180 / (float)M_PI));
 			if (yaw < 0)
 				yaw += 360;
 
 			forward = sqrtf (dist[0]*dist[0] + dist[1]*dist[1]);
-			pitch = (int) (atan2f(dist[2], forward) * 180 / M_PI);
+			pitch = (int) (atan2f(dist[2], forward) * (180 / (float)M_PI));
 			if (pitch < 0)
 				pitch += 360;
 		}

--- a/source/console.c
+++ b/source/console.c
@@ -499,7 +499,7 @@ void Con_DrawInput (void)
 	text = key_lines[edit_line];
 	
 // add the cursor frame
-	text[key_linepos] = 10+((int)(realtime*con_cursorspeed)&1);
+	text[key_linepos] = 10+((int)((float)realtime*con_cursorspeed)&1);
 	
 // fill out remainder with spaces
 	for (i=key_linepos+1 ; i< con_linewidth ; i++)
@@ -541,7 +541,7 @@ void Con_DrawNotify (void)
 		time = con_times[i % NUM_CON_TIMES];
 		if (time == 0)
 			continue;
-		time = realtime - time;
+		time = (float)realtime - time;
 		if (time > con_notifytime.value)
 			continue;
 		text = con_text + (i % con_totallines)*con_linewidth;
@@ -569,7 +569,7 @@ void Con_DrawNotify (void)
 			Draw_Character ( (x+5)<<3, v, chat_buffer[x]);
 			x++;
 		}
-		Draw_Character ( (x+5)<<3, v, 10+((int)(realtime*con_cursorspeed)&1));
+		Draw_Character ( (x+5)<<3, v, 10+((int)((float)realtime*con_cursorspeed)&1));
 		v += 8;
 	}
 	

--- a/source/crypter.c
+++ b/source/crypter.c
@@ -12,16 +12,16 @@ char rotate(char c, int key)
     if(c < 'A')
 	   c += l;
 
-    if(c > 'Z')
+	if(c > 'Z')
 	   c -= l;
 
-    return c;
+	return c;
 }
 
 char encrypt(char c, int key)
 {
     if(c >= 'a' && c <= 'z')
-	   c = toupper(c);
+	   c = c + ('A'-'a'); // toupper
 
 	if(c >= 'A' && c <= 'Z')
 	   c = rotate(c, key);

--- a/source/ctr/gl/gl_draw.c
+++ b/source/ctr/gl/gl_draw.c
@@ -485,9 +485,9 @@ void Draw_CharacterRGBA(int x, int y, int num, float r, float g, float b, float 
 	row = num>>4;
 	col = num&15;
 
-	frow = row*0.0625;
-	fcol = col*0.0625;
-	size = 0.0625*scale;
+	frow = row*0.0625f;
+	fcol = col*0.0625f;
+	size = 0.0625f*scale;
 
 	GL_Bind (char_texture);
 
@@ -530,9 +530,9 @@ void Draw_ColoredString(int x, int y, char *str, float r, float g, float b, floa
 		// Hooray for variable-spacing!
 		if (*str == ' ')
 			x += 4 * (int)scale;
-        else if ((int)*str < 33 || (int)*str > 126)
+		else if ((int)*str < 33 || (int)*str > 126)
             x += 8 * (int)scale;
-        else
+		else
             x += (font_kerningamount[(int)(*str - 33)] + 1) * (int)scale;
 		
 		str++;
@@ -547,9 +547,9 @@ int getTextWidth(char *str, float scale)
         // Hooray for variable-spacing!
 		if (str[i] == ' ')
 			width += 4 * (int)scale;
-        else if ((int)str[i] < 33 || (int)str[i] > 126)
+		else if ((int)str[i] < 33 || (int)str[i] > 126)
             width += 8 * (int)scale;
-        else
+		else
             width += (font_kerningamount[(int)(str[i] - 33)] + 1) * (int)scale;
     }
 
@@ -1125,7 +1125,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-    else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+	else if (crosshair_spread_time < sv.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;
@@ -1146,27 +1146,27 @@ void Draw_Crosshair (void)
 			crosshair_offset = CrossHairMaxSpread();
 
 		if (sv_player->v.view_ofs[2] == 8) {
-			crosshair_offset *= 0.80;
+			crosshair_offset *= 0.80f;
 		} else if (sv_player->v.view_ofs[2] == -10) {
-			crosshair_offset *= 0.65;
+			crosshair_offset *= 0.65f;
 		}
 
-		crosshair_offset_step += (crosshair_offset - crosshair_offset_step) * 0.5;
+		crosshair_offset_step += (crosshair_offset - crosshair_offset_step) * 0.5f;
 
-		x_value = (vid.width - 3)/2 - crosshair_offset_step;
-		y_value = (vid.height - 1)/2;
+		x_value = (vid.width - 3)/2.0f - crosshair_offset_step;
+		y_value = (vid.height - 1)/2.0f;
 		Draw_FillByColor(x_value, y_value, 3, 1, 255, (int)col, (int)col, (int)crosshair_opacity);
 
-		x_value = (vid.width - 3)/2 + crosshair_offset_step;
-		y_value = (vid.height - 1)/2;
+		x_value = (vid.width - 3)/2.0f + crosshair_offset_step;
+		y_value = (vid.height - 1)/2.0f;
 		Draw_FillByColor(x_value, y_value, 3, 1, 255, (int)col, (int)col, (int)crosshair_opacity);
 
-		x_value = (vid.width - 1)/2;
-		y_value = (vid.height - 3)/2 - crosshair_offset_step;
+		x_value = (vid.width - 1)/2.0f;
+		y_value = (vid.height - 3)/2.0f - crosshair_offset_step;
 		Draw_FillByColor(x_value, y_value, 1, 3, 255, (int)col, (int)col, (int)crosshair_opacity);
 
-		x_value = (vid.width - 1)/2;
-		y_value = (vid.height - 3)/2 + crosshair_offset_step;
+		x_value = (vid.width - 1)/2.0f;
+		y_value = (vid.height - 3)/2.0f + crosshair_offset_step;
 		Draw_FillByColor(x_value, y_value, 1, 3, 255, (int)col, (int)col, (int)crosshair_opacity);
 	}
 	// Area of Effect (o)
@@ -1187,22 +1187,22 @@ void Draw_Crosshair (void)
 		crosshair_pulse_grenade = false;
 
 		crosshair_offset = 12 + cur_spread;
-		crosshair_offset_step += (crosshair_offset - crosshair_offset_step) * 0.5;
+		crosshair_offset_step += (crosshair_offset - crosshair_offset_step) * 0.5f;
 
-		x_value = (vid.width - 3)/2 - crosshair_offset_step;
-		y_value = (vid.height - 1)/2;
+		x_value = (vid.width - 3)/2.0f - crosshair_offset_step;
+		y_value = (vid.height - 1)/2.0f;
 		Draw_FillByColor(x_value, y_value, 3, 1, 255, 255, 255, 255);
 
-		x_value = (vid.width - 3)/2 + crosshair_offset_step;
-		y_value = (vid.height - 1)/2;
+		x_value = (vid.width - 3)/2.0f + crosshair_offset_step;
+		y_value = (vid.height - 1)/2.0f;
 		Draw_FillByColor(x_value, y_value, 3, 1, 255, 255, 255, 255);
 
-		x_value = (vid.width - 1)/2;
-		y_value = (vid.height - 3)/2 - crosshair_offset_step;
+		x_value = (vid.width - 1)/2.0f;
+		y_value = (vid.height - 3)/2.0f - crosshair_offset_step;
 		Draw_FillByColor(x_value, y_value, 1, 3, 255, 255, 255, 255);
 
-		x_value = (vid.width - 1)/2;
-		y_value = (vid.height - 3)/2 + crosshair_offset_step;
+		x_value = (vid.width - 1)/2.0f;
+		y_value = (vid.height - 3)/2.0f + crosshair_offset_step;
 		Draw_FillByColor(x_value, y_value, 1, 3, 255, 255, 255, 255);
 	}
 }
@@ -2257,7 +2257,10 @@ PixEncode:
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_JPEG
 #define STBI_ONLY_PNG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
 #include "../../stb_image.h"
+#pragma GCC diagnostic pop
 byte* LoadSTBI(FILE *f, int width, int height)
 {
 	int bpp;

--- a/source/ctr/gl/gl_fog.c
+++ b/source/ctr/gl/gl_fog.c
@@ -53,17 +53,17 @@ void Fog_Update (float start, float end, float red, float green, float blue, flo
 	if (time > 0)
 	{
 		//check for a fade in progress
-		if (fade_done > cl.time)
+		if (fade_done > (float)cl.time)
 		{
 			float f;
 
-			f = (fade_done - cl.time) / fade_time;
-			old_start = f * old_start + (1.0 - f) * fog_start;
-			old_end = f * old_end + (1.0 - f) * fog_end;
-			old_red = f * old_red + (1.0 - f) * fog_red;
-			old_green = f * old_green + (1.0 - f) * fog_green;
-			old_blue = f * old_blue + (1.0 - f) * fog_blue;
-			old_density = f * old_density + (1.0 - f) * fog_density_gl;
+			f = (fade_done - (float)cl.time) / fade_time;
+			old_start = f * old_start + (1.0f - f) * fog_start;
+			old_end = f * old_end + (1.0f - f) * fog_end;
+			old_red = f * old_red + (1.0f - f) * fog_red;
+			old_green = f * old_green + (1.0f - f) * fog_green;
+			old_blue = f * old_blue + (1.0f - f) * fog_blue;
+			old_density = f * old_density + (1.0f - f) * fog_density_gl;
 		}
 		else
 		{
@@ -82,8 +82,8 @@ void Fog_Update (float start, float end, float red, float green, float blue, flo
 	fog_green = green;
 	fog_blue = blue;
 	fade_time = time;
-	fade_done = cl.time + time;
-	fog_density_gl = ((fog_start / fog_end))/3.5;
+	fade_done = (float)cl.time + time;
+	fog_density_gl = ((fog_start / fog_end))/3.5f;
 }
 
 /*
@@ -133,12 +133,12 @@ void Fog_FogCommand_f (void)
 		Con_Printf("   fog <start> <end> <red> <green> <blue>\n");
 		Con_Printf("   fog <start> <end> <red> <green> <blue> <fade>\n");
 		Con_Printf("current values:\n");
-		Con_Printf("   \"start\" is \"%f\"\n", fog_start);
-		Con_Printf("   \"end\" is \"%f\"\n", fog_end);
-		Con_Printf("   \"red\" is \"%f\"\n", fog_red);
-		Con_Printf("   \"green\" is \"%f\"\n", fog_green);
-		Con_Printf("   \"blue\" is \"%f\"\n", fog_blue);
-		Con_Printf("   \"fade\" is \"%f\"\n", fade_time);
+		Con_Printf("   \"start\" is \"%f\"\n", (double)fog_start);
+		Con_Printf("   \"end\" is \"%f\"\n", (double)fog_end);
+		Con_Printf("   \"red\" is \"%f\"\n", (double)fog_red);
+		Con_Printf("   \"green\" is \"%f\"\n", (double)fog_green);
+		Con_Printf("   \"blue\" is \"%f\"\n", (double)fog_blue);
+		Con_Printf("   \"fade\" is \"%f\"\n", (double)fade_time);
 		break;
 	case 2: //TEST
 		Fog_Update(fog_start,
@@ -251,10 +251,10 @@ void Fog_ParseWorldspawn (void)
 			sscanf(value, "%f %f %f %f %f", &fog_start, &fog_end, &fog_red, &fog_green, &fog_blue);
 		}
 
-		fog_density_gl = ((fog_start / fog_end))/3.5;
+		fog_density_gl = ((fog_start / fog_end))/3.5f;
 	}
 
-	if (r_refdef.fog_start <= 0.01 || r_refdef.fog_end <= 0.01) {
+	if (r_refdef.fog_start <= 0.01f || r_refdef.fog_end <= 0.01f) {
 		r_refdef.fog_start = 0.0f;
 		r_refdef.fog_end = 0.0f;
 	}
@@ -274,28 +274,28 @@ float *Fog_GetColor (void)
 	float f;
 	int i;
 
-	if (fade_done > cl.time)
+	if (fade_done > (float)cl.time)
 	{
-		f = (fade_done - cl.time) / fade_time;
-		c[0] = f * old_red + (1.0 - f) * fog_red;
-		c[1] = f * old_green + (1.0 - f) * fog_green;
-		c[2] = f * old_blue + (1.0 - f) * fog_blue;
-		c[3] = 1.0;
+		f = (fade_done - (float)cl.time) / fade_time;
+		c[0] = f * old_red + (1.0f - f) * fog_red;
+		c[1] = f * old_green + (1.0f - f) * fog_green;
+		c[2] = f * old_blue + (1.0f - f) * fog_blue;
+		c[3] = 1.0f;
 	}
 	else
 	{
 		c[0] = fog_red;
 		c[1] = fog_green;
 		c[2] = fog_blue;
-		c[3] = 1.0;
+		c[3] = 1.0f;
 	}
 
 	//find closest 24-bit RGB value, so solid-colored sky can match the fog perfectly
 	for (i=0;i<3;i++)
-		c[i] = (float)(rint(c[i] * 255)) / 255.0f;
+		c[i] = (float)(rintf(c[i] * 255)) / 255.0f;
 
 	for (i = 0; i < 3; i++)
-		c[i] /= 64.0;
+		c[i] /= 64.0f;
 
 	return c;
 }
@@ -312,10 +312,10 @@ float Fog_GetDensity (void)
 {
 	float f;
 
-	if (fade_done > cl.time)
+	if (fade_done > (float)cl.time)
 	{
-		f = (fade_done - cl.time) / fade_time;
-		return f * old_density + (1.0 - f) * fog_density_gl;
+		f = (fade_done - (float)cl.time) / fade_time;
+		return f * old_density + (1.0f - f) * fog_density_gl;
 	}
 	else
 		return fog_density_gl;
@@ -375,10 +375,10 @@ float Fog_GetStart (void)
 {
 	float f;
 
-	if (fade_done > cl.time)
+	if (fade_done > (float)cl.time)
 	{
-		f = (fade_done - cl.time) / fade_time;
-		return f * old_start + (1.0 - f) * fog_start;
+		f = (fade_done - (float)cl.time) / fade_time;
+		return f * old_start + (1.0f - f) * fog_start;
 	}
 	else
 		return fog_start;
@@ -394,10 +394,10 @@ float Fog_GetEnd (void)
 {
 	float f;
 
-	if (fade_done > cl.time)
+	if (fade_done > (float)cl.time)
 	{
-		f = (fade_done - cl.time) / fade_time;
-		return f * old_start + (1.0 - f) * fog_end;
+		f = (fade_done - (float)cl.time) / fade_time;
+		return f * old_start + (1.0f - f) * fog_end;
 	}
 	else
 		return fog_end;

--- a/source/ctr/gl/gl_main.h
+++ b/source/ctr/gl/gl_main.h
@@ -49,7 +49,7 @@ extern	TEXSUBIMAGEPTR TexSubImage2DFunc;
 extern	int texture_extension_number;
 extern	int		texture_mode;
 
-extern	float	gldepthmin, gldepthmax;
+extern	double	gldepthmin, gldepthmax;
 
 void GL_Upload32 (unsigned *data, int width, int height,  qboolean mipmap, qboolean alpha);
 void GL_Upload8 (byte *data, int width, int height,  qboolean mipmap, qboolean alpha);
@@ -110,7 +110,7 @@ half-life Render Modes. Crow_bar
 
 // r_local.h -- private refresh defs
 
-#define ALIAS_BASE_SIZE_RATIO		(1.0 / 11.0)
+#define ALIAS_BASE_SIZE_RATIO		(1.0f / 11.0f)
 					// normalizing factor so player model works out to about
 					//  1 pixel per triangle
 #define	MAX_LBM_HEIGHT		480

--- a/source/ctr/gl/gl_mesh.c
+++ b/source/ctr/gl/gl_mesh.c
@@ -259,9 +259,9 @@ void BuildTris (void)
 			s = stverts[k].s;
 			t = stverts[k].t;
 			if (!triangles[besttris[0]].facesfront && stverts[k].onseam)
-				s += pheader->skinwidth / 2;	// on back side
-			s = (s + 0.5) / pheader->skinwidth;
-			t = (t + 0.5) / pheader->skinheight;
+				s += pheader->skinwidth / 2.0f;	// on back side
+			s = (s + 0.5f) / pheader->skinwidth;
+			t = (t + 0.5f) / pheader->skinheight;
 
 			memcpy(&commands[numcommands++], &s, sizeof(float));
 			memcpy(&commands[numcommands++], &t, sizeof(float));

--- a/source/ctr/gl/gl_model.c
+++ b/source/ctr/gl/gl_model.c
@@ -745,11 +745,11 @@ void Mod_LoadTexinfo (lump_t *l)
 		len1 = Length (out->vecs[0]);
 		len2 = Length (out->vecs[1]);
 		len1 = (len1 + len2)/2;
-		if (len1 < 0.32)
+		if (len1 < 0.32f)
 			out->mipadjust = 4;
-		else if (len1 < 0.49)
+		else if (len1 < 0.49f)
 			out->mipadjust = 3;
-		else if (len1 < 0.99)
+		else if (len1 < 0.99f)
 			out->mipadjust = 2;
 		else
 			out->mipadjust = 1;
@@ -1272,7 +1272,7 @@ float RadiusFromBounds (vec3_t mins, vec3_t maxs)
 
 	for (i=0 ; i<3 ; i++)
 	{
-		corner[i] = fabs(mins[i]) > fabs(maxs[i]) ? fabs(mins[i]) : fabs(maxs[i]);
+		corner[i] = fabsf(mins[i]) > fabsf(maxs[i]) ? fabsf(mins[i]) : fabsf(maxs[i]);
 	}
 
 	return Length (corner);
@@ -1433,9 +1433,9 @@ void Mod_LoadBrushModel (model_t *mod, void *buffer)
 
 		if (i < mod->numsubmodels-1)
 		{	// duplicate the basic information
-			char	name[11];
+			char	name[13];
 
-			snprintf (name, 12, "*%i", i+1);
+			snprintf (name, sizeof(name)-1, "*%i", i+1);
 			loadmodel = Mod_FindName (name);
 			*loadmodel = *mod;
 			strcpy (loadmodel->name, name);
@@ -2013,7 +2013,7 @@ void * Mod_LoadSpriteGroup (void * pin, mspriteframe_t **ppframe, int framenum)
 	for (i=0 ; i<numframes ; i++)
 	{
 		*poutintervals = LittleFloat (pin_intervals->interval);
-		if (*poutintervals <= 0.0)
+		if (*poutintervals <= 0.0f)
 			Sys_Error ("Mod_LoadSpriteGroup: interval<=0");
 
 		poutintervals++;
@@ -2068,10 +2068,10 @@ void Mod_LoadSpriteModel (model_t *mod, void *buffer)
 	mod->synctype = LittleLong (pin->synctype);
 	psprite->numframes = numframes;
 
-	mod->mins[0] = mod->mins[1] = -psprite->maxwidth/2;
-	mod->maxs[0] = mod->maxs[1] = psprite->maxwidth/2;
-	mod->mins[2] = -psprite->maxheight/2;
-	mod->maxs[2] = psprite->maxheight/2;
+	mod->mins[0] = mod->mins[1] = -psprite->maxwidth/2.0f;
+	mod->maxs[0] = mod->maxs[1] = psprite->maxwidth/2.0f;
+	mod->mins[2] = -psprite->maxheight/2.0f;
+	mod->maxs[2] = psprite->maxheight/2.0f;
 	
 //
 // load the frames

--- a/source/ctr/gl/gl_qmb.c
+++ b/source/ctr/gl/gl_qmb.c
@@ -611,21 +611,21 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			p->size = 1.175;
 			VectorCopy (org, p->org);
 			tempSize = size * 2;
-			p->vel[0] = (rand() % (int)tempSize) - ((int)tempSize / 2);
-			p->vel[1] = (rand() % (int)tempSize) - ((int)tempSize / 2);
-			p->vel[2] = (rand() % (int)tempSize) - ((int)tempSize / 2);
+			p->vel[0] = (int)(rand() % (int)tempSize) - (int)((int)tempSize / 2);
+			p->vel[1] = (int)(rand() % (int)tempSize) - (int)((int)tempSize / 2);
+			p->vel[2] = (int)(rand() % (int)tempSize) - (int)((int)tempSize / 2);
 			break;
 		case p_rayspark:
-			p->size = 1.175;
+			p->size = 1.175f;
 			VectorCopy (org, p->org);
 			tempSize = size * 2;
-			p->vel[0] = (rand() % (int)tempSize) - ((int)tempSize/6);
-			p->vel[1] = (rand() % (int)tempSize) - ((int)tempSize/6);
+			p->vel[0] = (int)(rand() % (int)tempSize) - (int)((int)tempSize/6);
+			p->vel[1] = (int)(rand() % (int)tempSize) - (int)((int)tempSize/6);
 			p->vel[2] = /*(rand() % (int)tempSize) - (*/(int)tempSize;
 			break;
 		case p_raysmoke:
 			for (j=0 ; j<3 ; j++)
-				p->org[j] = org[j] + ((rand() & 31) - 16) / 2.0;
+				p->org[j] = org[j] + ((rand() & 31) - 16) / 2.0f;
 
 			p->vel[0] = ((rand() % 10)+2);
 			p->vel[1] = ((rand() % 10)+2);
@@ -634,7 +634,7 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			break;
 		case p_smoke:
 			for (j=0 ; j<3 ; j++)
-				p->org[j] = org[j] + ((rand() & 31) - 16) / 2.0;
+				p->org[j] = org[j] + ((rand() & 31) - 16) / 2.0f;
 			for (j=0 ; j<3 ; j++)
 				p->vel[j] = ((rand() % 10) - 5) / 20.0;
 			p->growth = 4.5;
@@ -659,7 +659,7 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			break;
 
 		case p_bubble:
-			p->start += (rand() & 15) / 36.0;
+			p->start += (rand() & 15) / 36.0f;
 			p->org[0] = org[0] + ((rand() & 31) - 16);
 			p->org[1] = org[1] + ((rand() & 31) - 16);
 			p->org[2] = org[2] + ((rand() & 63) - 32);
@@ -737,7 +737,7 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			VectorCopy (org, p->org);
 			p->rotspeed = (rand() & 45) - 90;
 			//p->size = size * (rand() % 6) / 4;//r00k
-			p->size = size * (0.75 +((0.05 * (rand() % 20)) * 0.5));//blubs: resultant size range: [size * 0.75, size * 1.25)
+			p->size = size * (0.75f +((0.05f * (rand() % 20)) * 0.5f));//blubs: resultant size range: [size * 0.75, size * 1.25)
 			break;
 
 		case p_teleflare:
@@ -748,7 +748,7 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			break;
 
 		case p_blood1:
-			p->size = size * (rand() % 2) + 0.50;//r00k
+			p->size = size * (rand() % 2) + 0.50f;//r00k
 			for (j=0 ; j<3 ; j++)
 				p->org[j] = org[j] + (rand() & 15) - 8;
 			for (j=0 ; j<3 ; j++)
@@ -764,7 +764,7 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			break;
 
 		case p_blood3:
-			p->size = size * (rand() % 20) / 5.0;
+			p->size = size * (rand() % 20) / 5.0f;
 			VectorCopy (org, p->org);
 			for (j=0 ; j<3 ; j++)
 				p->vel[j] = (rand() % 40) - 20;
@@ -848,28 +848,28 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 	case p_alphatrail:
 	case p_trailpart:
 	case p_lavatrail:
-		count = length / 1.1;
+		count = length / 1.1f;
 		break;
 
 	case p_blood3:
-		count = length / 8;
+		count = length / 8.0f;
 		break;
 
 	case p_bubble:
 	case p_bubble2:
-		count = length / 5.0;
+		count = length / 5.0f;
 		break;
 
 	case p_smoke:
-		count = length / 3.8;
+		count = length / 3.8f;
 		break;
 
 	case p_dpsmoke:
-		count = length / 2.5;
+		count = length / 2.5f;
 		break;
 
 	case p_dpfire:
-		count = length / 2.8;
+		count = length / 2.8f;
 		break;
 
 	default:
@@ -899,10 +899,10 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 		case p_blood3:
 			VectorCopy (point, p->org);
 			for (j=0 ; j<3 ; j++)
-				p->org[j] += ((rand() & 15) - 8) / 8.0;
+				p->org[j] += ((rand() & 15) - 8) / 8.0f;
 			for (j=0 ; j<3 ; j++)
-				p->vel[j] = ((rand() & 15) - 8) / 2.0;
-			p->size = size * (rand() % 20) / 10.0;
+				p->vel[j] = ((rand() & 15) - 8) / 2.0f;
+			p->size = size * (rand() % 20) / 10.0f;
 			p->growth = 6;
 			break;
 
@@ -917,19 +917,19 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 			VectorCopy (point, p->org);
 
 			for (j=0 ; j<3 ; j++)
-				p->org[j] += ((rand() & 15) - 8) / 8.0;
+				p->org[j] += ((rand() & 15) - 8) / 8.0f;
 
 			for (j=0 ; j<3 ; j++)
-				p->vel[j] = ((rand() & 15) - 8) / 2.0;
+				p->vel[j] = ((rand() & 15) - 8) / 2.0f;
 
-			p->size = size * (rand() % 20) / 10.0;
+			p->size = size * (rand() % 20) / 10.0f;
 			p->growth = 1;
 			break;
 
 		case p_smoke:
 			VectorCopy (point, p->org);
 			for (j=0 ; j<3 ; j++)
-				p->org[j] += ((rand() & 7) - 4) / 8.0;
+				p->org[j] += ((rand() & 7) - 4) / 8.0f;
 			p->vel[0] = p->vel[1] = 0;
 			p->vel[2] = rand() & 3;
 			p->growth = 4.5;
@@ -1001,7 +1001,7 @@ inline static void QMB_UpdateParticles(void)
 
 	particle_count = 0;
 	frametime = fabs(cl.ctime - cl.oldtime);
-	grav = sv_gravity.value / 800.0;
+	grav = sv_gravity.value / 800.0f;
 
 	for (i=0 ; i<num_particletypes ; i++)
 	{
@@ -1321,8 +1321,8 @@ void DRAW_PARTICLE_BILLBOARD(particle_texture_t *ptex, particle_t *p, vec3_t *co
     float subTexBottom = ptex->coords[p->texindex][3];
 
     glTexCoord2f(subTexLeft, subTexTop);
-    VectorMA(p->org, -scale * 0.5, up, p_downleft);
-    VectorMA(p_downleft, -scale * 0.5, right, p_downleft);
+    VectorMA(p->org, -scale * 0.5f, up, p_downleft);
+    VectorMA(p_downleft, -scale * 0.5f, right, p_downleft);
     glVertex3fv (p_downleft);
 
     glTexCoord2f(subTexRight, subTexTop);
@@ -1702,10 +1702,10 @@ void QMB_Shockwave_Splash(vec3_t org, int radius)
 
 	angle[2] = 0;
 
-	for (theta = 0; theta < 6.283185307179586476925286766559; theta += 0.069813170079773183076947630739545)
+	for (theta = 0; theta < 6.283185307179586476925286766559f; theta += 0.069813170079773183076947630739545f)
 	{
-		angle[0] = cos(theta) * radius;
-		angle[1] = sin(theta) * radius;
+		angle[0] = cosf(theta) * radius;
+		angle[1] = sinf(theta) * radius;
 		AddParticle(p_shockwave, org, 1, 2, 0.625f, NULL, angle);
 	}
 }
@@ -1801,15 +1801,15 @@ __inline static void AddColoredParticle (part_type_t type, vec3_t org, int count
 			p->size = 1.175;
 			VectorCopy (org, p->org);
 			tempSize = size * 2;
-			p->vel[0] = (rand() % (int)tempSize) - ((int)tempSize / 4);
-			p->vel[1] = (rand() % (int)tempSize) - ((int)tempSize / 4);
-			p->vel[2] = (rand() % (int)tempSize) - ((int)tempSize / 6);
+			p->vel[0] = (rand() % (int)tempSize) - (int)((int)tempSize / 4);
+			p->vel[1] = (rand() % (int)tempSize) - (int)((int)tempSize / 4);
+			p->vel[2] = (rand() % (int)tempSize) - (int)((int)tempSize / 6);
 			break;
 
 		case p_fire:
 			VectorCopy (org, p->org);
 			for (j=0 ; j<3 ; j++)
-				p->vel[j] = ((rand() % 160) - 80) * (size / 25.0);
+				p->vel[j] = ((rand() % 160) - 80) * (size / 25.0f);
 			break;
 
 		default:
@@ -1914,7 +1914,7 @@ void QMB_Blood_Splat(part_type_t type, vec3_t org) //Shpuldified
 			VectorMA (org, 70, neworg, neworg);
 
 			AddParticle (type, org, 5, 1, 2, color, neworg);
-			angle[1] += 360 / 4;
+			angle[1] += 360.0f / 4;
 		}
 	}
 }
@@ -1981,12 +1981,12 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 
 			if (ISUNDERWATER(contents))//R00k
 			{
-				AddParticle (p_bubble, org, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+				AddParticle (p_bubble, org, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 			}
 			else
 
 			{
-				AddParticle (p_smoke, org, 1, 4, 0.825f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+				AddParticle (p_smoke, org, 1, 4, 0.825f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 			}
 		}
 		break;
@@ -2002,12 +2002,12 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 
 		if (ISUNDERWATER(contents))//R00k
 		{
-			AddParticle (p_bubble, org, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+			AddParticle (p_bubble, org, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 		}
 		else
 
 		{
-			AddParticle (p_smoke, org, 3, 12, 1.225f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+			AddParticle (p_smoke, org, 3, 12, 1.225f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 		}
 		break;
 
@@ -2022,12 +2022,12 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 
 			if (ISUNDERWATER(contents))//R00k
 			{
-				AddParticle (p_bubble, neworg, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+				AddParticle (p_bubble, neworg, 1, 2, 0.825f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 			}
 			else
 
 			{
-				AddParticle (p_smoke, neworg, 1, 6, 0.825f + ((rand() % 10) - 5) / 40.0, NULL, zerodir);
+				AddParticle (p_smoke, neworg, 1, 6, 0.825f + ((rand() % 10) - 5) / 40.0f, NULL, zerodir);
 			}
 
 			if ((i % particlecount) == 0)
@@ -2055,14 +2055,14 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 		color[0] = 0;
 		color[1] = 255;
 		color[2] = 0;
-		AddParticle (p_raysmoke, org, 3, 25, 1.225f + ((rand() % 10) - 2) / 40.0, color, zerodir);
+		AddParticle (p_raysmoke, org, 3, 25, 1.225f + ((rand() % 10) - 2) / 40.0f, color, zerodir);
 		AddParticle (p_rayspark, org, 12, 75, 0.6f,  color, zerodir);
 		break;
 	case 512:
 		color[0] = 255;
 		color[1] = 0;
 		color[2] = 0;
-		AddParticle (p_raysmoke, org, 3, 25, 1.225f + ((rand() % 10) - 2) / 40.0, color, zerodir);
+		AddParticle (p_raysmoke, org, 3, 25, 1.225f + ((rand() % 10) - 2) / 40.0f, color, zerodir);
 		AddParticle (p_rayspark, org, 12, 75, 0.6f,  color, zerodir);
 		break;
 	default:
@@ -2231,19 +2231,19 @@ void QMB_MuzzleFlash(vec3_t org)
 		if(size == 0 || cl.stats[STAT_ZOOM] == 2)
 			return;
 
-        switch(rand() % 3 + 1)
+        switch(rand() % 3)
         {
+            case 0:
+                AddParticle (p_muzzleflash, org, 1, size, timemod * (float)frametime, color, zerodir);
+                break;
             case 1:
-                AddParticle (p_muzzleflash, org, 1, size, timemod * frametime, color, zerodir);
+                AddParticle (p_muzzleflash2, org, 1, size, timemod * (float)frametime, color, zerodir);
                 break;
             case 2:
-                AddParticle (p_muzzleflash2, org, 1, size, timemod * frametime, color, zerodir);
-                break;
-            case 3:
-                AddParticle (p_muzzleflash3, org, 1, size, timemod * frametime, color, zerodir);
+                AddParticle (p_muzzleflash3, org, 1, size, timemod * (float)frametime, color, zerodir);
                 break;
             default:
-                AddParticle (p_muzzleflash, org, 1, size, timemod * frametime, color, zerodir);
+                AddParticle (p_muzzleflash, org, 1, size, timemod * (float)frametime, color, zerodir);
                 break;
         }
 	}
@@ -2407,7 +2407,7 @@ void QMB_BlobExplosion (vec3_t org)
 	AddParticle (p_fire, org, 15, 30, 1.4, color, zerodir);
 
 	vel[2] = 0;
-	for (theta = 0 ; theta < 6.28318530717958647692528676655901 ; theta += 0.0897597901025655210989326680937001)
+	for (theta = 0 ; theta < 6.28318530717958647692528676655901f ; theta += 0.0897597901025655210989326680937001f)
 	{
 		color[0] = (60 + (rand() & 15));
 		color[1] = (65 + (rand() & 15));
@@ -2419,24 +2419,24 @@ void QMB_BlobExplosion (vec3_t org)
 		neworg[0] = org[0] + vfpu_cosf(theta) * 6;
 		neworg[1] = org[1] + vfpu_sinf(theta) * 6;
 		#else
-		vel[0] = cos(theta) * 125;
-		vel[1] = sin(theta) * 125;
-		neworg[0] = org[0] + cos(theta) * 6;
-		neworg[1] = org[1] + sin(theta) * 6;
+		vel[0] = cosf(theta) * 125;
+		vel[1] = sinf(theta) * 125;
+		neworg[0] = org[0] + cosf(theta) * 6;
+		neworg[1] = org[1] + sinf(theta) * 6;
 		#endif
 		neworg[2] = org[2] + 0 - 10;
 		AddParticle (p_shockwave, neworg, 1, 4, 0.8, color, vel);
 		neworg[2] = org[2] + 0 + 10;
 		AddParticle (p_shockwave, neworg, 1, 4, 0.8, color, vel);
 
-		vel[0] *= 1.15;
-		vel[1] *= 1.15;
+		vel[0] *= 1.15f;
+		vel[1] *= 1.15f;
 		#ifdef PSP_VFPU
 		neworg[0] = org[0] + vfpu_cosf(theta) * 13;
 		neworg[1] = org[1] + vfpu_sinf(theta) * 13;
 		#else
-		neworg[0] = org[0] + cos(theta) * 13;
-		neworg[1] = org[1] + sin(theta) * 13;
+		neworg[0] = org[0] + cosf(theta) * 13;
+		neworg[1] = org[1] + sinf(theta) * 13;
 		#endif
 		neworg[2] = org[2] + 0;
 		AddParticle (p_shockwave, neworg, 1, 6, 1.0, color, vel);
@@ -2498,9 +2498,9 @@ void QMB_TeleportSplash (vec3_t org)
 			AngleVectors (angle, NULLVEC, NULLVEC, neworg);
 			VectorMA (org, 70, neworg, neworg);
 			AddParticle (p_sparkray, org, 1, 6 + (i & 3), 5, color, neworg);
-			angle[2] += 360 / 5;
+			angle[2] += 360.0f / 5;
 		}
-		angle[0] += 180 / 5;
+		angle[0] += 180.0f / 5;
 	}
 }
 
@@ -2520,16 +2520,16 @@ void QMB_InfernoFlame (vec3_t org)
 		}
 		else
 		{
-			AddParticle (p_inferno_flame, org, 1, 30, 13.125 * frametime, NULL, zerodir);
-			AddParticle (p_inferno_trail, org, 2, 1.75, 45.0 * frametime, NULL, zerodir);
-			AddParticle (p_inferno_trail, org, 2, 1.0, 52.5 * frametime, NULL, zerodir);
+			AddParticle (p_inferno_flame, org, 1, 30, 13.125f * frametime, NULL, zerodir);
+			AddParticle (p_inferno_trail, org, 2, 1.75, 45.0f * frametime, NULL, zerodir);
+			AddParticle (p_inferno_trail, org, 2, 1.0, 52.5f * frametime, NULL, zerodir);
 		}
 	}
 }
 
 void QMB_StaticBubble (entity_t *ent)
 {
-	AddParticle (p_staticbubble, ent->origin, 1, ent->frame == 1 ? 1.85 : 2.9, 0.001, NULL, zerodir);
+	AddParticle (p_staticbubble, ent->origin, 1, ent->frame == 1 ? 1.85f : 2.9f, 0.001f, NULL, zerodir);
 }
 
 void QMB_TorchFlame (vec3_t org)
@@ -2685,9 +2685,9 @@ void QMB_Lightning_Splash(vec3_t org)
 			VectorMA (org, 20, neworg, neworg);
 			AddParticle (p_spark, org, 2, 85, 0.05f, NULL, zerodir);
 			AddParticle (p_spark, org, 2, 100, 0.1f, col2, neworg);
-			angle[2] += 360 / 5;
+			angle[2] += 360.0f / 5;
 	  }
-	  angle[0] += 180 / 5;
+	  angle[0] += 180.0f / 5;
 	}
 	color[0] = 224 + (rand() & 31);
 	color[1] = 100 + (rand() & 31);
@@ -2817,13 +2817,13 @@ void QMB_EntityParticles (entity_t *ent)
 
 	for (i=0 ; i<NUMVERTEXNORMALS ; i++)
 	{
-		angle = cl.time * avelocities[i][0];
-		sy = sin(angle);
-		cy = cos(angle);
-		angle = cl.time * avelocities[i][1];
-		sp = sin(angle);
-		cp = cos(angle);
-		angle = cl.time * avelocities[i][2];
+		angle = (float)cl.time * avelocities[i][0];
+		sy = sinf(angle);
+		cy = cosf(angle);
+		angle = (float)cl.time * avelocities[i][1];
+		sp = sinf(angle);
+		cp = cosf(angle);
+		angle = (float)cl.time * avelocities[i][2];
 
 		forward[0] = cp*cy;
 		forward[1] = cp*sy;

--- a/source/ctr/gl/gl_rlight.c
+++ b/source/ctr/gl/gl_rlight.c
@@ -212,10 +212,10 @@ start:
 			impact[j] = light->origin[j] - surf->plane->normal[j]*dist;
 		// clamp center of light to corner and check brightness
 		l = DotProduct (impact, surf->texinfo->vecs[0]) + surf->texinfo->vecs[0][3] - surf->texturemins[0];
-		s = l+0.5;if (s < 0) s = 0;else if (s > surf->extents[0]) s = surf->extents[0];
+		s = l+0.5f;if (s < 0) s = 0;else if (s > surf->extents[0]) s = surf->extents[0];
 		s = l - s;
 		l = DotProduct (impact, surf->texinfo->vecs[1]) + surf->texinfo->vecs[1][3] - surf->texturemins[1];
-		t = l+0.5;if (t < 0) t = 0;else if (t > surf->extents[1]) t = surf->extents[1];
+		t = l+0.5f;if (t < 0) t = 0;else if (t > surf->extents[1]) t = surf->extents[1];
 		t = l - t;
 		// compare to minimum light
 		if ((s*s+t*t+dist*dist) < maxdist)
@@ -252,7 +252,7 @@ void R_PushDlights (void)
 
 	for (i=0 ; i<MAX_DLIGHTS ; i++, l++)
 	{
-		if (l->die < cl.time || !l->radius)
+		if (l->die < (float)cl.time || !l->radius)
 			continue;
 		R_MarkLights (l, i, cl.worldmodel->nodes);
 	}
@@ -330,8 +330,8 @@ loc0:
 		// ericw -- added double casts to force 64-bit precision.
 		// Without them the zombie at the start of jam3_ericw.bsp was
 		// incorrectly being lit up in SSE builds.
-			ds = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[0]) + surf->texinfo->vecs[0][3]);
-			dt = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[1]) + surf->texinfo->vecs[1][3]);
+			ds = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[0]) + (double)surf->texinfo->vecs[0][3]);
+			dt = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[1]) + (double)surf->texinfo->vecs[1][3]);
 
 			if (ds < surf->texturemins[0] || dt < surf->texturemins[1])
 				continue;
@@ -354,7 +354,7 @@ loc0:
 
 				for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != 255;maps++)
 				{
-					scale = (float) d_lightstylevalue[surf->styles[maps]] * 1.0 / 256.0;
+					scale = (float) d_lightstylevalue[surf->styles[maps]] * 1.0f / 256.0f;
 					r00 += (float) lightmap[      0] * scale;g00 += (float) lightmap[      1] * scale;b00 += (float) lightmap[2] * scale;
 					r01 += (float) lightmap[      3] * scale;g01 += (float) lightmap[      4] * scale;b01 += (float) lightmap[5] * scale;
 					r10 += (float) lightmap[line3+0] * scale;g10 += (float) lightmap[line3+1] * scale;b10 += (float) lightmap[line3+2] * scale;

--- a/source/ctr/gl/gl_rmain.c
+++ b/source/ctr/gl/gl_rmain.c
@@ -195,7 +195,7 @@ void R_InterpolateEntity(entity_t *e, int shadow)	// Tomaz - New Shadow
 	
 	// positional interpolation
 	
-	timepassed = realtime - e->translate_start_time;
+	timepassed = (float)realtime - e->translate_start_time;
 	
 	//notes to self (blubs)
 	//-Added this method, and commented out the check for r_i_model_transforms.value
@@ -222,7 +222,7 @@ void R_InterpolateEntity(entity_t *e, int shadow)	// Tomaz - New Shadow
 	}
 	else
 	{
-		blend =  timepassed / 0.4;//0.1 not sure what this value should be...
+		blend =  timepassed / 0.4f;//0.1 not sure what this value should be...
 		//technically this value should be the total amount of time that we take from 1 position to the next, it's practically how long it should take us to go from one location to the next...
 		if (cl.paused || blend > 1)
 			blend = 0;
@@ -233,7 +233,7 @@ void R_InterpolateEntity(entity_t *e, int shadow)	// Tomaz - New Shadow
 	glTranslatef (e->origin[0] + (blend * deltaVec[0]),  e->origin[1] + (blend * deltaVec[1]),  e->origin[2] + (blend * deltaVec[2]));
 
 	// orientation interpolation (Euler angles, yuck!)
-	timepassed = realtime - e->rotate_start_time;
+	timepassed = (float)realtime - e->rotate_start_time;
 	
 	if (e->rotate_start_time == 0 || timepassed > 1)
 	{
@@ -251,7 +251,7 @@ void R_InterpolateEntity(entity_t *e, int shadow)	// Tomaz - New Shadow
 	}
 	else
 	{
-		blend = timepassed / 0.1;
+		blend = timepassed / 0.1f;
 		if (cl.paused || blend > 1)
 			blend = 1;
 	}
@@ -271,11 +271,11 @@ void R_InterpolateEntity(entity_t *e, int shadow)	// Tomaz - New Shadow
 		}
 	}
 
-	glRotatef ((e->angles1[YAW] + ( blend * deltaVec[YAW])) * (M_PI / 180.0f),  0, 0, 1);
+	glRotatef ((e->angles1[YAW] + ( blend * deltaVec[YAW])) * ((float)M_PI / 180.0f),  0, 0, 1);
 	if (shadow == 0)
 	{
-		glRotatef ((-e->angles1[PITCH] + (-blend * deltaVec[PITCH])) * (M_PI / 180.0f),  0, 1, 0);
-    	glRotatef ((e->angles1[ROLL] + ( blend * deltaVec[ROLL])) * (M_PI / 180.0f),  1, 0, 0);
+		glRotatef ((-e->angles1[PITCH] + (-blend * deltaVec[PITCH])) * ((float)M_PI / 180.0f),  0, 1, 0);
+    	glRotatef ((e->angles1[ROLL] + ( blend * deltaVec[ROLL])) * ((float)M_PI / 180.0f),  1, 0, 0);
 	}
 }
 
@@ -342,7 +342,7 @@ mspriteframe_t *R_GetSpriteFrame (entity_t *currententity)
 		numframes = pspritegroup->numframes;
 		fullinterval = pintervals[numframes-1];
 
-		time = cl.time + currententity->syncbase;
+		time = (float)cl.time + currententity->syncbase;
 
 	// when loading in Mod_LoadSpriteGroup, we guaranteed all interval values
 	// are positive, so we don't have to worry about division by 0
@@ -607,7 +607,7 @@ void GL_DrawAliasShadow (aliashdr_t *paliashdr, int posenum)
 	verts += posenum * paliashdr->poseverts;
 	order = (int *)((byte *)paliashdr + paliashdr->commands);
 
-	height = -lheight + 1.0;
+	height = -lheight + 1.0f;
 
 	while (1)
 	{
@@ -671,7 +671,7 @@ void R_SetupAliasFrame (int frame, aliashdr_t *paliashdr)
 	if (numposes > 1)
 	{
 		interval = paliashdr->frames[frame].interval;
-		pose += (int)(cl.time / interval) % numposes;
+		pose += (int)((float)cl.time / interval) % numposes;
 	}
 	
 	GL_DrawAliasFrame(paliashdr, pose);
@@ -718,7 +718,7 @@ void R_SetupAliasBlendedFrame (int frame, aliashdr_t *paliashdr, entity_t* e)
 		if (numposes > 1)
 		{
 			e->frame_interval = paliashdr->frames[frame].interval;
-			pose += (int)(cl.time / e->frame_interval) % numposes;
+			pose += (int)((float)cl.time / e->frame_interval) % numposes;
 		}
 		else
 		{
@@ -739,7 +739,7 @@ void R_SetupAliasBlendedFrame (int frame, aliashdr_t *paliashdr, entity_t* e)
 			blend = 0;
 		}
 		else
-			blend = (realtime - e->frame_start_time) / e->frame_interval;
+			blend = ((float)realtime - e->frame_start_time) / e->frame_interval;
 		// wierd things start happening if blend passes 1
 		if (cl.paused || blend > 1) blend = 1;
 
@@ -1013,7 +1013,7 @@ void R_DrawAliasModel (entity_t *e)
 
 	for (lnum=0 ; lnum<MAX_DLIGHTS ; lnum++)
 	{
-		if (cl_dlights[lnum].die >= cl.time)
+		if (cl_dlights[lnum].die >= (float)cl.time)
 		{
 			VectorSubtract (currententity->origin,
 							cl_dlights[lnum].origin,
@@ -1045,12 +1045,12 @@ void R_DrawAliasModel (entity_t *e)
 		|| !strcmp (clmodel->name, "progs/flame.mdl") )
 		ambientlight = shadelight = 256;
 
-	shadedots = r_avertexnormal_dots[((int)(e->angles[1] * (SHADEDOT_QUANT / 360.0))) & (SHADEDOT_QUANT - 1)];
-	shadelight = shadelight / 200.0;
+	shadedots = r_avertexnormal_dots[((int)(e->angles[1] * (SHADEDOT_QUANT / 360.0f))) & (SHADEDOT_QUANT - 1)];
+	shadelight = shadelight / 200.0f;
 	
-	an = e->angles[1]/180*M_PI;
-	shadevector[0] = cos(-an);
-	shadevector[1] = sin(-an);
+	an = e->angles[1]/180*(float)M_PI;
+	shadevector[0] = cosf(-an);
+	shadevector[1] = sinf(-an);
 	shadevector[2] = 1;
 	VectorNormalize (shadevector);
 
@@ -1107,7 +1107,7 @@ void R_DrawAliasModel (entity_t *e)
 
 		// Special handling of view model to keep FOV from altering look.  Pretty good.  Not perfect but rather close.
 		if ((e == &cl.viewent || e == &cl.viewent2) && scr_fov_viewmodel.value) {
-			float scale = 1.0f / tan (DEG2RAD (scr_fov.value / 2.0f)) * scr_fov_viewmodel.value / 90.0f;
+			float scale = 1.0f / tanf (DEG2RAD (scr_fov.value / 2.0f)) * scr_fov_viewmodel.value / 90.0f;
 			if (e->scale != ENTSCALE_DEFAULT && e->scale != 0) scale *= ENTSCALE_DECODE(e->scale);
 			glTranslatef (paliashdr->scale_origin[0] * scale, paliashdr->scale_origin[1], paliashdr->scale_origin[2]);
 			glScalef (paliashdr->scale[0] * scale, paliashdr->scale[1], paliashdr->scale[2]);
@@ -1340,7 +1340,7 @@ void R_DrawView2Model (void)
 			continue;
 		if (!dl->radius)
 			continue;
-		if (dl->die < cl.time)
+		if (dl->die < (float)cl.time)
 			continue;
 
 		VectorSubtract (currententity->origin, dl->origin, dist);
@@ -1409,7 +1409,7 @@ void R_DrawViewModel (void)
 			continue;
 		if (!dl->radius)
 			continue;
-		if (dl->die < cl.time)
+		if (dl->die < (float)cl.time)
 			continue;
 
 		VectorSubtract (currententity->origin, dl->origin, dist);
@@ -1503,13 +1503,13 @@ void R_SetFrustum (void)
 		// naievil -- hi, this is floored because any basically non integer(? i think short precision float) value made the rendering all fucked up
 		// so hope this helps (it does). This reduces some accuracy but it is not as important
 		// rotate VPN right by FOV_X/2 degrees
-		RotatePointAroundVector( frustum[0].normal, vup, vpn, floor(-(90-r_refdef.fov_x / 2 )) );
+		RotatePointAroundVector( frustum[0].normal, vup, vpn, floorf(-(90-r_refdef.fov_x / 2 )) );
 		// rotate VPN left by FOV_X/2 degrees
-		RotatePointAroundVector( frustum[1].normal, vup, vpn, floor(90-r_refdef.fov_x / 2) );
+		RotatePointAroundVector( frustum[1].normal, vup, vpn, floorf(90-r_refdef.fov_x / 2) );
 		// rotate VPN up by FOV_X/2 degrees
-		RotatePointAroundVector( frustum[2].normal, vright, vpn, floor(90-r_refdef.fov_y / 2) );
+		RotatePointAroundVector( frustum[2].normal, vright, vpn, floorf(90-r_refdef.fov_y / 2) );
 		// rotate VPN down by FOV_X/2 degrees
-		RotatePointAroundVector( frustum[3].normal, vright, vpn, floor(-( 90 - r_refdef.fov_y / 2 )) );
+		RotatePointAroundVector( frustum[3].normal, vright, vpn, floorf(-( 90 - r_refdef.fov_y / 2 )) );
 	}
 
 	for (i=0 ; i<4 ; i++)
@@ -1691,7 +1691,7 @@ R_Clear
 */
 void R_Clear (void)
 {
-	if (r_mirroralpha.value != 1.0)
+	if (r_mirroralpha.value != 1.0f)
 	{
 		if (gl_clear.value)
 			glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1758,8 +1758,8 @@ void R_Mirror (void)
 	d = DotProduct (vpn, mirror_plane->normal);
 	VectorMA (vpn, -2*d, mirror_plane->normal, vpn);
 
-	r_refdef.viewangles[0] = -asin (vpn[2])/M_PI*180;
-	r_refdef.viewangles[1] = atan2 (vpn[1], vpn[0])/M_PI*180;
+	r_refdef.viewangles[0] = -asinf (vpn[2])/(float)M_PI*180;
+	r_refdef.viewangles[1] = atan2f (vpn[1], vpn[0])/(float)M_PI*180;
 	r_refdef.viewangles[2] = -r_refdef.viewangles[2];
 
 	ent = &cl_entities[cl.viewentity];

--- a/source/ctr/gl/gl_rmisc.c
+++ b/source/ctr/gl/gl_rmisc.c
@@ -467,7 +467,7 @@ void R_NewMap (void)
 			skytexturenum = i;
 		if (!strncmp(cl.worldmodel->textures[i]->name,"window02_1",10) )
 			mirrortexturenum = i;
- 		cl.worldmodel->textures[i]->texturechain = NULL;
+		cl.worldmodel->textures[i]->texturechain = NULL;
 	}
 	//R_LoadSkys ();
 }
@@ -498,7 +498,7 @@ void R_TimeRefresh_f (void)
 	glFinish ();
 	stop = Sys_FloatTime ();
 	time = stop-start;
-	Con_Printf ("%f seconds (%f fps)\n", time, 128/time);
+	Con_Printf ("%f seconds (%f fps)\n", (double)time, (double)128/(double)time);
 
 	glDrawBuffer  (GL_BACK);
 	GL_EndRendering ();

--- a/source/ctr/gl/gl_rsurf.c
+++ b/source/ctr/gl/gl_rsurf.c
@@ -92,7 +92,7 @@ void R_AddDynamicLights (msurface_t *surf)
 		rad = cl_dlights[lnum].radius;
 		dist = DotProduct (cl_dlights[lnum].origin, surf->plane->normal) -
 				surf->plane->dist;
-		rad -= fabs(dist);
+		rad -= fabsf(dist);
 		minlight = cl_dlights[lnum].minlight;
 		if (rad < minlight)
 			continue;
@@ -475,8 +475,8 @@ void R_DrawSequentialPoly (msurface_t *s)
 			qglMTexCoord2fSGIS (TEXTURE0_SGIS, v[3], v[4]);
 			qglMTexCoord2fSGIS (TEXTURE1_SGIS, v[5], v[6]);
 
-			nv[0] = v[0] + 8*sin(v[1]*0.05+realtime)*sin(v[2]*0.05+realtime);
-			nv[1] = v[1] + 8*sin(v[0]*0.05+realtime)*sin(v[2]*0.05+realtime);
+			nv[0] = v[0] + 8*sinf(v[1]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
+			nv[1] = v[1] + 8*sinf(v[0]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
 			nv[2] = v[2];
 
 			glVertex3fv (nv);
@@ -518,8 +518,8 @@ void DrawGLWaterPoly (glpoly_t *p)
 	{
 		glTexCoord2f (v[3], v[4]);
 
-		nv[0] = v[0] + 8*sin(v[1]*0.05+realtime)*sin(v[2]*0.05+realtime);
-		nv[1] = v[1] + 8*sin(v[0]*0.05+realtime)*sin(v[2]*0.05+realtime);
+		nv[0] = v[0] + 8*sinf(v[1]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
+		nv[1] = v[1] + 8*sinf(v[0]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
 		nv[2] = v[2];
 
 		glVertex3fv (nv);
@@ -541,8 +541,8 @@ void DrawGLWaterPolyLightmap (glpoly_t *p)
 	{
 		glTexCoord2f (v[5], v[6]);
 
-		nv[0] = v[0] + 8*sin(v[1]*0.05+realtime)*sin(v[2]*0.05+realtime);
-		nv[1] = v[1] + 8*sin(v[0]*0.05+realtime)*sin(v[2]*0.05+realtime);
+		nv[0] = v[0] + 8*sinf(v[1]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
+		nv[1] = v[1] + 8*sinf(v[0]*0.05f+(float)realtime)*sinf(v[2]*0.05f+(float)realtime);
 		nv[2] = v[2];
 
 		glVertex3fv (nv);
@@ -869,7 +869,7 @@ void R_DrawWaterSurfaces (void)
 	msurface_t	*s;
 	texture_t	*t;
 
-	if (r_wateralpha.value == 1.0 && gl_texsort.value)
+	if (r_wateralpha.value == 1.0f && gl_texsort.value)
 		return;
 
 	//
@@ -878,7 +878,7 @@ void R_DrawWaterSurfaces (void)
 
     glLoadMatrixf (r_world_matrix);
 
-	if (r_wateralpha.value < 1.0) {
+	if (r_wateralpha.value < 1.0f) {
 		glEnable (GL_BLEND);
 		glColor4f (1,1,1,r_wateralpha.value);
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
@@ -919,7 +919,7 @@ void R_DrawWaterSurfaces (void)
 
 	}
 
-	if (r_wateralpha.value < 1.0) {
+	if (r_wateralpha.value < 1.0f) {
 		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 
 		glColor4f (1,1,1,1);
@@ -963,14 +963,14 @@ void DrawTextureChains (void)
 		s = t->texturechain;
 		if (!s)
 			continue;
-		else if (i == mirrortexturenum && r_mirroralpha.value != 1.0)
+		else if (i == mirrortexturenum && r_mirroralpha.value != 1.0f)
 		{
 			R_MirrorChain (s);
 			continue;
 		}
 		else
 		{
-			if ((s->flags & SURF_DRAWTURB) && r_wateralpha.value != 1.0)
+			if ((s->flags & SURF_DRAWTURB) && r_wateralpha.value != 1.0f)
 				continue;	// draw translucent water later
 			for ( ; s ; s=s->texturechain)
 				R_RenderBrushPoly (s);
@@ -1045,7 +1045,7 @@ void R_DrawBrushModel (entity_t *e)
 	{
 		for (k=0 ; k<MAX_DLIGHTS ; k++)
 		{
-			if ((cl_dlights[k].die < cl.time) ||
+			if ((cl_dlights[k].die < (float)cl.time) ||
 				(!cl_dlights[k].radius))
 				continue;
 
@@ -1118,8 +1118,8 @@ void R_DrawBrushModel (entity_t *e)
 		dot = DotProduct (modelorg, pplane->normal) - pplane->dist;
 
 	// draw the polygon
-		if (((psurf->flags & SURF_PLANEBACK) && (dot < -BACKFACE_EPSILON)) ||
-			(!(psurf->flags & SURF_PLANEBACK) && (dot > BACKFACE_EPSILON)))
+		if (((psurf->flags & SURF_PLANEBACK) && (dot < (float)-BACKFACE_EPSILON)) ||
+			(!(psurf->flags & SURF_PLANEBACK) && (dot > (float)BACKFACE_EPSILON)))
 		{
 			R_RenderBrushPoly (psurf);
 		}
@@ -1148,7 +1148,7 @@ void R_RecursiveWorldNode (mnode_t *node)
 	mplane_t	*plane;
 	msurface_t	*surf, **mark;
 	mleaf_t		*pleaf;
-	double		dot;
+	float		dot;
 
 	if (node->contents == CONTENTS_SOLID)
 		return;		// solid
@@ -1218,9 +1218,9 @@ void R_RecursiveWorldNode (mnode_t *node)
 	{
 		surf = cl.worldmodel->surfaces + node->firstsurface;
 
-		if (dot < 0 -BACKFACE_EPSILON)
+		if (dot < (float)-BACKFACE_EPSILON)
 			side = SURF_PLANEBACK;
-		else if (dot > BACKFACE_EPSILON)
+		else if (dot > (float)BACKFACE_EPSILON)
 			side = 0;
 		{
 			for ( ; c ; c--, surf++)
@@ -1293,8 +1293,8 @@ void R_AddBrushModelToChains (entity_t * e)
 		mplane_t * pplane = psurf->plane;
 		float dot = DotProduct (modelorg, pplane->normal) - pplane->dist;
 		// draw the polygon
-		if (((psurf->flags & SURF_PLANEBACK) && (dot < -BACKFACE_EPSILON)) ||
-			(!(psurf->flags & SURF_PLANEBACK) && (dot > BACKFACE_EPSILON)))
+		if (((psurf->flags & SURF_PLANEBACK) && (dot < (float)-BACKFACE_EPSILON)) ||
+			(!(psurf->flags & SURF_PLANEBACK) && (dot > (float)BACKFACE_EPSILON)))
 		{
 			// psurf->flags &= ~SURF_NEEDSCLIPPING;
 			// psurf->flags |= SURF_NEEDSCLIPPING * (frustum_check > 1);
@@ -1552,10 +1552,10 @@ void BuildSurfaceDisplayList (msurface_t *fa)
 			VectorNormalize( v2 );
 
 			// skip co-linear points
-			#define COLINEAR_EPSILON 0.001
-			if ((fabs( v1[0] - v2[0] ) <= COLINEAR_EPSILON) &&
-				(fabs( v1[1] - v2[1] ) <= COLINEAR_EPSILON) && 
-				(fabs( v1[2] - v2[2] ) <= COLINEAR_EPSILON))
+			#define COLINEAR_EPSILON 0.001f
+			if ((fabsf( v1[0] - v2[0] ) <= COLINEAR_EPSILON) &&
+				(fabsf( v1[1] - v2[1] ) <= COLINEAR_EPSILON) && 
+				(fabsf( v1[2] - v2[2] ) <= COLINEAR_EPSILON))
 			{
 				int j;
 				for (j = i + 1; j < lnumverts; ++j)

--- a/source/ctr/gl/gl_screen.c
+++ b/source/ctr/gl/gl_screen.c
@@ -179,7 +179,7 @@ void SCR_DrawCenterString (void)
 
 // the finale prints the characters one at a time
 	if (cl.intermission)
-		remaining = scr_printspeed.value * (cl.time - scr_centertime_start);
+		remaining = scr_printspeed.value * ((float)cl.time - scr_centertime_start);
 	else
 		remaining = 9999;
 
@@ -231,7 +231,7 @@ void SCR_CheckDrawCenterString (void)
 	if (scr_center_lines > scr_erase_lines)
 		scr_erase_lines = scr_center_lines;
 
-	scr_centertime_off -= host_frametime;
+	scr_centertime_off -= (float)host_frametime;
 	
 	if (scr_centertime_off <= 0 && !cl.intermission)
 		return;
@@ -545,7 +545,7 @@ void SCR_CheckDrawUseString (void)
 {
 	scr_copytop = 1;
 
-	scr_usetime_off -= host_frametime;
+	scr_usetime_off -= (float)host_frametime;
 
 	if ((scr_usetime_off <= 0 && !cl.intermission) || key_dest != key_game || cl.stats[STAT_HEALTH] <= 0)
 		return;
@@ -566,13 +566,13 @@ float CalcFov (float fov_x, float width, float height)
         float   x;
 
         if (fov_x < 1 || fov_x > 179)
-                Sys_Error ("Bad fov: %f", fov_x);
+                Sys_Error ("Bad fov: %f", (double)fov_x);
 
-        x = width/tanf(fov_x/360*M_PI);
+        x = width/tanf(fov_x/360.0f*(float)M_PI);
 
         a = atanf (height/x);
 
-        a = a*360/M_PI;
+        a = a*360.0f/(float)M_PI;
 
         return a;
 }
@@ -623,7 +623,7 @@ static void SCR_CalcRefdef (void)
 	else
 		sb_lines = 24+16+8;
 
-	if (scr_viewsize.value >= 100.0) {
+	if (scr_viewsize.value >= 100.0f) {
 		full = true;
 		size = 100.0;
 	} else
@@ -634,7 +634,7 @@ static void SCR_CalcRefdef (void)
 		size = 100;
 		sb_lines = 0;
 	}
-	size /= 100.0;
+	size /= 100.0f;
 
 	h = vid.height - sb_lines;
 
@@ -793,9 +793,9 @@ int Random_Int (int max_int)
 	float	f;
 	f = (rand ()&0x7fff) / ((float)0x7fff) * max_int;
 	if (f > 0)
-		return (int)(f + 0.5) + 1;
+		return (int)(f + 0.5f) + 1;
 	else
-		return (int)(f - 0.5) + 1;
+		return (int)(f - 0.5f) + 1;
 }
 /*
 ==============
@@ -1140,20 +1140,20 @@ void SCR_SetUpToDrawConsole (void)
 		scr_con_current = scr_conlines;
 	}
 	else if (key_dest == key_console)
-		scr_conlines = vid.height/2;	// half screen
+		scr_conlines = vid.height/2.0f;	// half screen
 	else
 		scr_conlines = 0;				// none visible
 
 	if (scr_conlines < scr_con_current)
 	{
-		scr_con_current -= scr_conspeed.value*host_frametime;
+		scr_con_current -= scr_conspeed.value*(float)host_frametime;
 		if (scr_conlines > scr_con_current)
 			scr_con_current = scr_conlines;
 
 	}
 	else if (scr_conlines > scr_con_current)
 	{
-		scr_con_current += scr_conspeed.value*host_frametime;
+		scr_con_current += scr_conspeed.value*(float)host_frametime;
 		if (scr_conlines < scr_con_current)
 			scr_con_current = scr_conlines;
 	}
@@ -1413,7 +1413,7 @@ needs almost the entire 256k of stack space!
 ==================
 */
 
-int GetWeaponZoomAmmount (void)
+int GetWeaponZoomAmount (void)
 {
     switch (cl.stats[STAT_ACTIVEWEAPON])
     {
@@ -1525,7 +1525,7 @@ void SCR_UpdateScreen (void)
 
 	if (scr_disabled_for_loading)
 	{
-		if (realtime - scr_disabled_time > 60)
+		if ((float)realtime - scr_disabled_time > 60)
 		{
 			scr_disabled_for_loading = false;
 			Con_Printf ("load failed.\n");
@@ -1549,10 +1549,10 @@ void SCR_UpdateScreen (void)
 			original_view_fov = scr_fov_viewmodel.value;
 		}
 			
-		if(scr_fov.value > (GetWeaponZoomAmmount() + 1))//+1 for accounting for floating point inaccurraces
+		if(scr_fov.value > (GetWeaponZoomAmount() + 1))//+1 for accounting for floating point inaccurraces
 		{
-			scr_fov.value += ((original_fov - GetWeaponZoomAmmount()) - scr_fov.value) * 0.25;
-			scr_fov_viewmodel.value += ((original_view_fov - GetWeaponZoomAmmount()) - scr_fov_viewmodel.value) * 0.25;
+			scr_fov.value += ((original_fov - GetWeaponZoomAmount()) - scr_fov.value) * 0.25f;
+			scr_fov_viewmodel.value += ((original_view_fov - GetWeaponZoomAmount()) - scr_fov_viewmodel.value) * 0.25f;
 			Cvar_SetValue("fov",scr_fov.value);
 			Cvar_SetValue("r_viewmodel_fov", scr_fov_viewmodel.value);
 		}
@@ -1567,8 +1567,8 @@ void SCR_UpdateScreen (void)
 	{
 		if(scr_fov.value < (original_fov + 1))//+1 for accounting for floating point inaccuracies
 		{
-			scr_fov.value += (original_fov - scr_fov.value) * 0.25;
-			scr_fov_viewmodel.value += (original_view_fov - scr_fov_viewmodel.value) * 0.25;
+			scr_fov.value += (original_fov - scr_fov.value) * 0.25f;
+			scr_fov_viewmodel.value += (original_view_fov - scr_fov_viewmodel.value) * 0.25f;
 			Cvar_SetValue("fov",scr_fov.value);
 			Cvar_SetValue("r_viewmodel_fov", scr_fov_viewmodel.value);
 		}

--- a/source/ctr/gl/gl_vidctr.c
+++ b/source/ctr/gl/gl_vidctr.c
@@ -28,7 +28,7 @@ int		texture_mode = GL_LINEAR;
 
 int		texture_extension_number = 1;
 
-float	gldepthmin, gldepthmax;
+double	gldepthmin, gldepthmax;
 
 cvar_t	gl_ztrick = {"gl_ztrick","0"};
 
@@ -61,8 +61,8 @@ void GL_Init (void)
 
 #pragma GCC diagnostic pop
 
-	glClearDepth (1.0f);
-	glClearColor ((float)(16/255),(float)(32/255),(float)(64/255),1);
+	glClearDepth (1.0);
+	glClearColor ((float)(16.0f/255),(float)(32.0f/255),(float)(64.0f/255),1);
 	glCullFace(GL_FRONT);
 	glEnable(GL_TEXTURE_2D);
 
@@ -177,8 +177,8 @@ static void Check_Gamma (unsigned char *pal)
 
 	for (i=0 ; i<768 ; i++)
 	{
-		f = pow ( (pal[i]+1)/256.0 , vid_gamma );
-		inf = f*255 + 0.5;
+		f = powf ( (pal[i]+1)/256.0 , vid_gamma );
+		inf = f*255 + 0.5f;
 		if (inf < 0)
 			inf = 0;
 		if (inf > 255)
@@ -229,7 +229,7 @@ void	VID_Init (unsigned char *palette)
 	vid.height = 240;
 
 	vid.aspect = ((float)vid.height / (float)vid.width) *
-				(320.0 / 240.0);
+				(320.0f / 240.0f);
 	vid.numpages = 2;
 
 	GL_Init();

--- a/source/ctr/gl/gl_warp.c
+++ b/source/ctr/gl/gl_warp.c
@@ -77,8 +77,8 @@ void SubdividePolygon (int numverts, float *verts)
 
 	for (i=0 ; i<3 ; i++)
 	{
-		m = (mins[i] + maxs[i]) * 0.5;
-		m = gl_subdivide_size.value * floor (m/gl_subdivide_size.value + 0.5);
+		m = (mins[i] + maxs[i]) * 0.5f;
+		m = gl_subdivide_size.value * floorf (m/gl_subdivide_size.value + 0.5f);
 		if (maxs[i] - m < 8)
 			continue;
 		if (m - mins[i] < 8)
@@ -210,11 +210,11 @@ void EmitWaterPolys (msurface_t *fa)
 			os = v[3];
 			ot = v[4];
 
-			s = os + turbsin[(int)((ot*0.125+realtime) * TURBSCALE) & 255];
-			s *= (1.0/64);
+			s = os + turbsin[(int)((ot*0.125f+(float)realtime) * (float)TURBSCALE) & 255];
+			s *= (1.0f/64);
 
-			t = ot + turbsin[(int)((os*0.125+realtime) * TURBSCALE) & 255];
-			t *= (1.0/64);
+			t = ot + turbsin[(int)((os*0.125f+(float)realtime) * (float)TURBSCALE) & 255];
+			t *= (1.0f/64);
 
 			glTexCoord2f (s, t);
 			glVertex3fv (v);
@@ -249,14 +249,14 @@ void EmitSkyPolys (msurface_t *fa)
 			dir[2] *= 3;	// flatten the sphere
 
 			length = dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2];
-			length = sqrt (length);
+			length = sqrtf (length);
 			length = 6*63/length;
 
 			dir[0] *= length;
 			dir[1] *= length;
 
-			s = (speedscale + dir[0]) * (1.0/128);
-			t = (speedscale + dir[1]) * (1.0/128);
+			s = (speedscale + dir[0]) * (1.0f/128);
+			t = (speedscale + dir[1]) * (1.0f/128);
 
 			glTexCoord2f (s, t);
 			glVertex3fv (v);
@@ -544,19 +544,19 @@ void MakeSkyVec (float s, float t, int axis)
 	}
 
 	// avoid bilerp seam
-	s = (s+1)*0.5;
-	t = (t+1)*0.5;
+	s = (s+1)*0.5f;
+	t = (t+1)*0.5f;
 
-	if (s < 1.0/512)
-		s = 1.0/512;
-	else if (s > 511.0/512)
-		s = 511.0/512;
-	if (t < 1.0/512)
-		t = 1.0/512;
-	else if (t > 511.0/512)
-		t = 511.0/512;
+	if (s < 1.0f/512)
+		s = 1.0f/512;
+	else if (s > 511.0f/512)
+		s = 511.0f/512;
+	if (t < 1.0f/512)
+		t = 1.0f/512;
+	else if (t > 511.0f/512)
+		t = 511.0f/512;
 
-	t = 1.0 - t;
+	t = 1.0f - t;
 	glTexCoord2f (s, t);
 	glVertex3fv (v);
 }

--- a/source/ctr/in_ctr.c
+++ b/source/ctr/in_ctr.c
@@ -64,7 +64,7 @@ float IN_CalcInput(int axis, float speed, float tolerance, float acceleration) {
 		return 0.0f;
 	}
 
-	float abs_value = fabs(value);
+	float abs_value = fabsf(value);
 
 	if (abs_value < tolerance) {
 		return 0.0f;
@@ -143,13 +143,13 @@ void IN_Move (usercmd_t *cmd)
 
 	// cut look speed in half when facing enemy, unless mag is empty
 	if ((in_aimassist.value) && (sv_player->v.facingenemy == 1) && cl.stats[STAT_CURRENTMAG] > 0) {
-		speed *= 0.5;
+		speed *= 0.5f;
 	}
 	// additionally, slice look speed when ADS/scopes
 	if (cl.stats[STAT_ZOOM] == 1)
-		speed *= 0.5;
+		speed *= 0.5f;
 	else if (cl.stats[STAT_ZOOM] == 2)
-		speed *= 0.25;
+		speed *= 0.25f;
 	
 	// Are we using the left or right stick for looking?
 	if (!in_anub_mode.value) { // Left
@@ -161,13 +161,13 @@ void IN_Move (usercmd_t *cmd)
 	}
 
 	const float yawScale = 30.0f;
-	cl.viewangles[YAW] -= yawScale * look_x * host_frametime;
+	cl.viewangles[YAW] -= yawScale * look_x * (float)host_frametime;
 
 	// Set the pitch.
 	const bool invertPitch = m_pitch.value < 0;
 	const float pitchScale = yawScale * (invertPitch ? 1 : -1);
 
-	cl.viewangles[PITCH] += pitchScale * look_y * host_frametime;
+	cl.viewangles[PITCH] += pitchScale * look_y * (float)host_frametime;
 
 	// Don't look too far up or down.
 	if (cl.viewangles[PITCH] > 80.0f)
@@ -188,8 +188,8 @@ void IN_Move (usercmd_t *cmd)
 	}
 
 	cl_backspeed = cl_forwardspeed = cl_sidespeed = sv_player->v.maxspeed;
-	cl_sidespeed *= 0.8;
-	cl_backspeed *= 0.7;
+	cl_sidespeed *= 0.8f;
+	cl_backspeed *= 0.7f;
 
 	move_x = IN_CalcInput(input_x, cl_sidespeed, deadZone, acceleration);
 

--- a/source/ctr/menu.c
+++ b/source/ctr/menu.c
@@ -335,34 +335,34 @@ static void M_Paused_Menu_Draw ()
 	// Header
 	Draw_ColoredString(10, 10, "PAUSED", 255, 255, 255, 255, 2);
 
-	if ((M_Paused_Cusor == 0))
+	if (M_Paused_Cusor == 0)
 		Draw_ColoredString(10, 135, "Resume", 255, 0, 0, 255, 1);
 	else
 		Draw_ColoredString(10, 135, "Resume", 255, 255, 255, 255, 1);
 
-	if ((M_Paused_Cusor == 1))
+	if (M_Paused_Cusor == 1)
 		Draw_ColoredString(10, 145, "Restart", 255, 0, 0, 255, 1);
 	else
 		Draw_ColoredString(10, 145, "Restart", 255, 255, 255, 255, 1);
 
-	if ((M_Paused_Cusor == 2))
+	if (M_Paused_Cusor == 2)
 		Draw_ColoredString(10, 155, "Settings", 255, 0, 0, 255, 1);
 	else
 		Draw_ColoredString(10, 155, "Settings", 255, 255, 255, 255, 1);
 
 	if (waypoint_mode.value) {
-		if ((M_Paused_Cusor == 3))
+		if (M_Paused_Cusor == 3)
 			Draw_ColoredString(10, 165, "Save Waypoints", 255, 0, 0, 255, 1);
 		else
 			Draw_ColoredString(10, 165, "Save Waypoints", 255, 255, 255, 255, 1);
 	} else {
-		if ((M_Paused_Cusor == 3))
+		if (M_Paused_Cusor == 3)
 			Draw_ColoredString(10, 165, "Achievements", 255, 0, 0, 255, 1);
 		else
 			Draw_ColoredString(10, 165, "Achievements", 255, 255, 255, 255, 1);
 	}
 
-	if ((M_Paused_Cusor == 4))
+	if (M_Paused_Cusor == 4)
 		Draw_ColoredString(10, 175, "Main Menu", 255, 0, 0, 255, 1);
 	else
 		Draw_ColoredString(10, 175, "Main Menu", 255, 255, 255, 255, 1);
@@ -1335,15 +1335,15 @@ void M_AdjustSliders (int dir)
 		Cvar_SetValue ("viewsize", scr_viewsize.value);
 		break;
 	case 4:	// gamma
-		v_gamma.value -= dir * 0.05;
-		if (v_gamma.value < 0.5)
-			v_gamma.value = 0.5;
+		v_gamma.value -= dir * 0.05f;
+		if (v_gamma.value < 0.5f)
+			v_gamma.value = 0.5f;
 		if (v_gamma.value > 1)
-			v_gamma.value = 1;
+			v_gamma.value = 1.0f;
 		Cvar_SetValue ("gamma", v_gamma.value);
 		break;
 	case 5:	// mouse speed
-		sensitivity.value += dir * 0.5;
+		sensitivity.value += dir * 0.5f;
 		if (sensitivity.value < 1)
 			sensitivity.value = 1;
 		if (sensitivity.value > 11)
@@ -1351,7 +1351,7 @@ void M_AdjustSliders (int dir)
 		Cvar_SetValue ("sensitivity", sensitivity.value);
 		break;
 	case 6:	// music volume
-		bgmvolume.value += dir * 0.1;
+		bgmvolume.value += dir * 0.1f;
 		if (bgmvolume.value < 0)
 			bgmvolume.value = 0;
 		if (bgmvolume.value > 1)
@@ -1359,7 +1359,7 @@ void M_AdjustSliders (int dir)
 		Cvar_SetValue ("bgmvolume", bgmvolume.value);
 		break;
 	case 7:	// sfx volume
-		volume.value += dir * 0.1;
+		volume.value += dir * 0.1f;
 		if (volume.value < 0)
 			volume.value = 0;
 		if (volume.value > 1)
@@ -1444,7 +1444,7 @@ void M_Options_Draw (void)
 	M_DrawSlider (220, 56, r);
 
 	M_Print (16, 64, "            Brightness");
-	r = (1.0 - v_gamma.value) / 0.5;
+	r = (1.0f - v_gamma.value) / 0.5f;
 	M_DrawSlider (220, 64, r);
 
 	M_Print (16, 72, "           Mouse Speed");

--- a/source/ctr/net.h
+++ b/source/ctr/net.h
@@ -299,7 +299,7 @@ typedef struct _PollProcedure
 {
 	struct _PollProcedure	*next;
 	double					nextTime;
-	void					(*procedure)();
+	void					(*procedure)(void*);
 	void					*arg;
 } PollProcedure;
 

--- a/source/ctr/net_dgrm.c
+++ b/source/ctr/net_dgrm.c
@@ -516,10 +516,10 @@ static int		testPollCount;
 static int		testDriver;
 static int		testSocket;
 
-static void Test_Poll(void);
+static void Test_Poll(void* unused);
 PollProcedure	testPollProcedure = {NULL, 0.0, Test_Poll};
 
-static void Test_Poll(void)
+static void Test_Poll(void* unused)
 {
 	struct qsockaddr clientaddr;
 	int		control;
@@ -638,10 +638,10 @@ static qboolean test2InProgress = false;
 static int		test2Driver;
 static int		test2Socket;
 
-static void Test2_Poll(void);
+static void Test2_Poll(void* unused);
 PollProcedure	test2PollProcedure = {NULL, 0.0, Test2_Poll};
 
-static void Test2_Poll(void)
+static void Test2_Poll(void* unused)
 {
 	struct qsockaddr clientaddr;
 	int		control;

--- a/source/ctr/net_main.c
+++ b/source/ctr/net_main.c
@@ -49,8 +49,8 @@ qboolean	slistLocal = true;
 static double	slistStartTime;
 static int		slistLastShown;
 
-static void Slist_Send(void);
-static void Slist_Poll(void);
+static void Slist_Send(void*);
+static void Slist_Poll(void*);
 PollProcedure	slistSendProcedure = {NULL, 0.0, Slist_Send};
 PollProcedure	slistPollProcedure = {NULL, 0.0, Slist_Poll};
 
@@ -312,7 +312,7 @@ void NET_Slist_f (void)
 }
 
 
-static void Slist_Send(void)
+static void Slist_Send(void* unused)
 {
 	for (net_driverlevel=0; net_driverlevel < net_numdrivers; net_driverlevel++)
 	{
@@ -328,7 +328,7 @@ static void Slist_Send(void)
 }
 
 
-static void Slist_Poll(void)
+static void Slist_Poll(void* unused)
 {
 	for (net_driverlevel=0; net_driverlevel < net_numdrivers; net_driverlevel++)
 	{
@@ -557,7 +557,7 @@ int	NET_GetMessage (qsocket_t *sock)
 	// see if this connection has timed out
 	if (ret == 0 && sock->driver)
 	{
-		if (net_time - sock->lastMessageTime > net_messagetimeout.value)
+		if (net_time - sock->lastMessageTime > (double)net_messagetimeout.value)
 		{
 			NET_Close(sock);
 			return -1;
@@ -933,7 +933,7 @@ void NET_Poll(void)
 	{
 		if (serialAvailable)
 		{
-			if (config_com_modem.value == 1.0)
+			if (config_com_modem.value == 1.0f)
 				useModem = true;
 			else
 				useModem = false;

--- a/source/ctr/r_part.c
+++ b/source/ctr/r_part.c
@@ -145,13 +145,13 @@ void R_EntityParticles (entity_t *ent)
 
 	for (i=0 ; i<NUMVERTEXNORMALS ; i++)
 	{
-		angle = cl.time * avelocities[i][0];
-		sy = sin(angle);
-		cy = cos(angle);
-		angle = cl.time * avelocities[i][1];
-		sp = sin(angle);
-		cp = cos(angle);
-		angle = cl.time * avelocities[i][2];
+		angle = (float)cl.time * avelocities[i][0];
+		sy = sinf(angle);
+		cy = cosf(angle);
+		angle = (float)cl.time * avelocities[i][1];
+		sp = sinf(angle);
+		cp = cosf(angle);
+		angle = (float)cl.time * avelocities[i][2];
 	
 		forward[0] = cp*cy;
 		forward[1] = cp*sy;
@@ -722,13 +722,13 @@ void R_Classic_DrawParticles (void)
 	time3 = frametime * 15;
 	time2 = frametime * 10; // 15;
 	time1 = frametime * 5;
-	grav = frametime * sv_gravity.value * 0.05;
+	grav = frametime * sv_gravity.value * 0.05f;
 	dvel = 4*frametime;
 	
 	for ( ;; ) 
 	{
 		kill = active_particles;
-		if (kill && kill->die < cl.time)
+		if (kill && kill->die < (float)cl.time)
 		{
 			active_particles = kill->next;
 			kill->next = free_particles;
@@ -743,7 +743,7 @@ void R_Classic_DrawParticles (void)
 		for ( ;; )
 		{
 			kill = p->next;
-			if (kill && kill->die < cl.time)
+			if (kill && kill->die < (float)cl.time)
 			{
 				p->next = kill->next;
 				kill->next = free_particles;
@@ -760,7 +760,7 @@ void R_Classic_DrawParticles (void)
 		if (scale < 20)
 			scale = 1;
 		else
-			scale = 1 + scale * 0.004;
+			scale = 1 + scale * 0.004f;
 		
 		glColor4ubv (p->color);
 		glTexCoord2f (0,0);

--- a/source/cvar.c
+++ b/source/cvar.c
@@ -436,7 +436,7 @@ void Cvar_SetValueQuick (cvar_t *var, const float value)
 		snprintf (val, sizeof(val), "%i", (int)value);
 	else
 	{
-		snprintf (val, sizeof(val), "%f", value);
+		snprintf (val, sizeof(val), "%f", (double)value);
 		// kill trailing zeroes
 		while (*ptr)
 			ptr++;
@@ -479,7 +479,7 @@ void Cvar_SetValue (const char *var_name, const float value)
 		snprintf (val, sizeof(val), "%i", (int)value);
 	else
 	{
-		snprintf (val, sizeof(val), "%f", value);
+		snprintf (val, sizeof(val), "%f", (double)value);
 		// kill trailing zeroes
 		while (*ptr)
 			ptr++;

--- a/source/host.c
+++ b/source/host.c
@@ -556,10 +556,10 @@ Returns false if the time is too short to run a frame
 */
 qboolean Host_FilterTime (float time)
 {
-	realtime += time;
+	realtime += (double)time;
 #ifndef __WII__
    if (cl_maxfps.value < 1) Cvar_SetValue("cl_maxfps", 30);
-   if (!cls.timedemo && realtime - oldrealtime < 1.0/cl_maxfps.value)
+   if (!cls.timedemo && realtime - oldrealtime < 1.0/(double)cl_maxfps.value)
 		return false;		// framerate is too high
 #else
 	if (!cls.timedemo && realtime - oldrealtime < 1.0f/60.0f)
@@ -571,10 +571,10 @@ qboolean Host_FilterTime (float time)
 
 	//johnfitz -- host_timescale is more intuitive than host_framerate
 	if (host_timescale.value > 0)
-		host_frametime *= host_timescale.value;
+		host_frametime *= (double)host_timescale.value;
 	//johnfitz
 	else if (host_framerate.value > 0)
-		host_frametime = host_framerate.value;
+		host_frametime = (double)host_framerate.value;
 	else // don't allow really long or short frames
 		host_frametime = CLAMP (0.001, host_frametime, 0.1); //johnfitz -- use CLAMP
 
@@ -631,7 +631,7 @@ void Host_ServerFrame (void)
 // send all messages to the clients
 	SV_SendClientMessages ();
 
-	if (sv.time >= 5.0f) {
+	if (sv.time >= 5.0) {
 		TestHandler_MapBoot();
 	}
 }
@@ -889,7 +889,7 @@ void Host_Init (quakeparms_t *parms)
 	host_parms = *parms;
 
 	if (parms->memsize < minimum_memory)
-		Sys_Error ("Only %4.1f megs of memory available, can't execute game", parms->memsize / (float)0x100000);
+		Sys_Error ("Only %4.1f megs of memory available, can't execute game", parms->memsize / (double)0x100000);
 
 	com_argc = parms->argc;
 	com_argv = parms->argv;
@@ -924,7 +924,7 @@ void Host_Init (quakeparms_t *parms)
 
 	Con_Printf ("VRAM Size: %i bytes\n", sceGeEdramGetSize());
 #elif __3DS__
-	Con_Printf ("3DS NZP v%4.1f (3DSX: "__TIME__" "__DATE__")\n", (float)(VERSION));
+	Con_Printf ("3DS NZP v%4.1f (3DSX: "__TIME__" "__DATE__")\n", (double)(VERSION));
 
 	if (new3ds_flag)
 		Con_Printf ("3DS Model: NEW Nintendo 3DS\n");

--- a/source/host_cmd.c
+++ b/source/host_cmd.c
@@ -495,7 +495,7 @@ void Host_Savegame_f (void)
 	Host_SavegameComment (comment);
 	fprintf (f, "%s\n", comment);
 	for (i=0 ; i<NUM_SPAWN_PARMS ; i++)
-		fprintf (f, "%f\n", svs.clients->spawn_parms[i]);
+		fprintf (f, "%f\n", (double)svs.clients->spawn_parms[i]);
 	fprintf (f, "%d\n", current_skill);
 	fprintf (f, "%s\n", sv.name);
 	fprintf (f, "%f\n",sv.time);
@@ -529,7 +529,7 @@ Host_Loadgame_f
 */
 void Host_Loadgame_f (void)
 {
-	char	name[MAX_OSPATH];
+	char	name[MAX_OSPATH+1];
 	FILE	*f;
 	char	mapname[MAX_QPATH];
 	float	time, tfloat;
@@ -551,7 +551,10 @@ void Host_Loadgame_f (void)
 
 	cls.demonum = -1;		// stop demo loop in case this fails
 
-	snprintf(name, MAX_OSPATH + 1, "%s/%s", com_gamedir, Cmd_Argv(1));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+	snprintf(name, MAX_OSPATH, "%s/%s", com_gamedir, Cmd_Argv(1));
+#pragma GCC diagnostic pop
 	COM_DefaultExtension (name, ".sav");
 
 // we can't call SCR_BeginLoadingPlaque, because too much stack space has
@@ -578,7 +581,7 @@ void Host_Loadgame_f (void)
 		fscanf (f, "%f\n", &spawn_parms[i]);
 // this silliness is so we can load 1.06 save files, which have float skill values
 	fscanf (f, "%f\n", &tfloat);
-	current_skill = (int)(tfloat + 0.1);
+	current_skill = (int)(tfloat + 0.1f);
 	Cvar_SetValue ("skill", (float)current_skill);
 
 	fscanf (f, "%s\n",mapname);
@@ -651,7 +654,7 @@ void Host_Loadgame_f (void)
 	}
 
 	sv.num_edicts = entnum;
-	sv.time = time;
+	sv.time = (double)time;
 
 	fclose (f);
 

--- a/source/mathlib.h
+++ b/source/mathlib.h
@@ -39,8 +39,8 @@ typedef	int	fixed16_t;
 #define M_PI		3.14159265358979323846	// matches value in gcc v2 math.h
 #endif
 
-#define RAD2DEG( x )	((float)(x) * (float)(180.f / M_PI))
-#define DEG2RAD( x )	((float)(x) * (float)(M_PI / 180.f))
+#define RAD2DEG( x )	((float)(x) * (float)(180.f / (float)M_PI))
+#define DEG2RAD( x )	((float)(x) * (float)((float)M_PI / 180.f))
 
 struct mplane_s;
 
@@ -66,7 +66,9 @@ extern	int nanmask;
 #define VectorNegate(a, b)	((b)[0] = -(a)[0], (b)[1] = -(a)[1], (b)[2] = -(a)[2])
 #define VectorSet(v, x, y, z)	((v)[0] = (x), (v)[1] = (y), (v)[2] = (z))
 #define VectorRandom(v) {do{(v)[0] = lhrandom(-1, 1);(v)[1] = lhrandom(-1, 1);(v)[2] = lhrandom(-1, 1);}while(DotProduct(v, v) > 1);}
-#define DoublePrecisionDotProduct(x,y) ((double)(x)[0]*(y)[0]+(double)(x)[1]*(y)[1]+(double)(x)[2]*(y)[2])
+#define DoublePrecisionDotProduct(x, y) \
+    ((double)(x)[0] * (double)(y)[0] + (double)(x)[1] * (double)(y)[1] + (double)(x)[2] * (double)(y)[2])
+
 #define VSM(a,b,c) {c[0]=a[0]*b;c[1]=a[1]*b;c[2]=a[2]*b;}
 
 #define VectorNormalizeFast( v ){float	ilength = (float)rsqrt(DotProduct(v,v));v[0] *= ilength;v[1] *= ilength;v[2] *= ilength; }
@@ -108,7 +110,7 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
 int BoxOnPlaneSide (vec3_t emins, vec3_t emaxs, struct mplane_s *plane);
 
 
-#define anglemod(a) ((360.0/65536) * ((int)((a)*(65536/360.0)) & 65535))
+#define anglemod(a) ((360.0f/65536) * ((int)((a)*(65536/360.0f)) & 65535))
 
 #define VectorL2Compare(v, w, m)					\
 	(_mathlib_temp_float1 = (m) * (m),				\

--- a/source/matrixlib.c
+++ b/source/matrixlib.c
@@ -119,11 +119,11 @@ void Matrix3x4_CreateFromEntity( matrix3x4 out, const vec3_t angles, const vec3_
 
 	if( angles[ROLL] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
-		angle = angles[PITCH] * (M_PI*2 / 360);
+		angle = angles[PITCH] * ((float)M_PI / 180);
 		SinCos( angle, &sp, &cp );
-		angle = angles[ROLL] * (M_PI*2 / 360);
+		angle = angles[ROLL] * ((float)M_PI / 180);
 		SinCos( angle, &sr, &cr );
 
 		out[0][0] = (cp*cy) * scale;
@@ -141,9 +141,9 @@ void Matrix3x4_CreateFromEntity( matrix3x4 out, const vec3_t angles, const vec3_
 	}
 	else if( angles[PITCH] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
-		angle = angles[PITCH] * (M_PI*2 / 360);
+		angle = angles[PITCH] * ((float)M_PI / 180);
 		SinCos( angle, &sp, &cp );
 
 		out[0][0] = (cp*cy) * scale;
@@ -161,7 +161,7 @@ void Matrix3x4_CreateFromEntity( matrix3x4 out, const vec3_t angles, const vec3_
 	}
 	else if( angles[YAW] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
 
 		out[0][0] = (cy) * scale;
@@ -196,7 +196,7 @@ void Matrix3x4_CreateFromEntity( matrix3x4 out, const vec3_t angles, const vec3_
 
 void Matrix3x4_TransformPositivePlane( const matrix3x4 in, const vec3_t normal, float d, vec3_t out, float *dist )
 {
-	float	scale = sqrt( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
+	float	scale = sqrtf( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
 	float	iscale = 1.0f / scale;
 
 	out[0] = (normal[0] * in[0][0] + normal[1] * in[0][1] + normal[2] * in[0][2]) * iscale;
@@ -211,7 +211,7 @@ void Matrix3x4_Invert_Simple( matrix3x4 out, const matrix3x4 in1 )
 	// (note the lack of sqrt here, because we're trying to undo the scaling,
 	// this means multiplying by the inverse scale twice - squaring it, which
 	// makes the sqrt a waste of time)
-	float	scale = 1.0 / (in1[0][0] * in1[0][0] + in1[0][1] * in1[0][1] + in1[0][2] * in1[0][2]);
+	float	scale = 1.0f / (in1[0][0] * in1[0][0] + in1[0][1] * in1[0][1] + in1[0][2] * in1[0][2]);
 
 	// invert the rotation by transposing and multiplying by the squared
 	// recipricol of the input matrix scale as described above
@@ -407,11 +407,11 @@ void Matrix4x4_CreateFromEntity( matrix4x4 out, const vec3_t angles, const vec3_
 
 	if( angles[ROLL] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
-		angle = angles[PITCH] * (M_PI*2 / 360);
+		angle = angles[PITCH] * ((float)M_PI / 180);
 		SinCos( angle, &sp, &cp );
-		angle = angles[ROLL] * (M_PI*2 / 360);
+		angle = angles[ROLL] * ((float)M_PI / 180);
 		SinCos( angle, &sr, &cr );
 
 		out[0][0] = (cp*cy) * scale;
@@ -433,9 +433,9 @@ void Matrix4x4_CreateFromEntity( matrix4x4 out, const vec3_t angles, const vec3_
 	}
 	else if( angles[PITCH] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
-		angle = angles[PITCH] * (M_PI*2 / 360);
+		angle = angles[PITCH] * ((float)M_PI / 180);
 		SinCos( angle, &sp, &cp );
 
 		out[0][0] = (cp*cy) * scale;
@@ -457,7 +457,7 @@ void Matrix4x4_CreateFromEntity( matrix4x4 out, const vec3_t angles, const vec3_
 	}
 	else if( angles[YAW] )
 	{
-		angle = angles[YAW] * (M_PI*2 / 360);
+		angle = angles[YAW] * ((float)M_PI / 180);
 		SinCos( angle, &sy, &cy );
 
 		out[0][0] = (cy) * scale;
@@ -500,19 +500,19 @@ void Matrix4x4_CreateFromEntity( matrix4x4 out, const vec3_t angles, const vec3_
 
 void Matrix4x4_ConvertToEntity( const matrix4x4 in, vec3_t angles, vec3_t origin )
 {
-	float xyDist = sqrt( in[0][0] * in[0][0] + in[1][0] * in[1][0] );
+	float xyDist = sqrtf( in[0][0] * in[0][0] + in[1][0] * in[1][0] );
 
 	// enough here to get angles?
 	if( xyDist > 0.001f )
 	{
-		angles[0] = RAD2DEG( atan2( -in[2][0], xyDist ) );
-		angles[1] = RAD2DEG( atan2( in[1][0], in[0][0] ) );
-		angles[2] = RAD2DEG( atan2( in[2][1], in[2][2] ) );
+		angles[0] = RAD2DEG( atan2f( -in[2][0], xyDist ) );
+		angles[1] = RAD2DEG( atan2f( in[1][0], in[0][0] ) );
+		angles[2] = RAD2DEG( atan2f( in[2][1], in[2][2] ) );
 	}
 	else	// forward is mostly Z, gimbal lock
 	{
-		angles[0] = RAD2DEG( atan2( -in[2][0], xyDist ) );
-		angles[1] = RAD2DEG( atan2( -in[0][1], in[1][1] ) );
+		angles[0] = RAD2DEG( atan2f( -in[2][0], xyDist ) );
+		angles[1] = RAD2DEG( atan2f( -in[0][1], in[1][1] ) );
 		angles[2] = 0;
 	}
 
@@ -551,7 +551,7 @@ void Matrix4x4_TransformPositivePlane( const matrix4x4 in, const vec3_t normal, 
 		: "m"( *in ), "m"( *normal ), "m"( d )
 	);
 #else
-	float	scale = sqrt( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
+	float	scale = sqrtf( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
 	float	iscale = 1.0f / scale;
 
 	out[0] = (normal[0] * in[0][0] + normal[1] * in[0][1] + normal[2] * in[0][2]) * iscale;
@@ -591,7 +591,7 @@ void Matrix4x4_TransformStandardPlane( const matrix4x4 in, const vec3_t normal, 
 		: "m"( *in ), "m"( *normal ), "m"( d )
 	);
 #else
-	float scale = sqrt( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
+	float scale = sqrtf( in[0][0] * in[0][0] + in[0][1] * in[0][1] + in[0][2] * in[0][2] );
 	float iscale = 1.0f / scale;
 
 	out[0] = (normal[0] * in[0][0] + normal[1] * in[0][1] + normal[2] * in[0][2]) * iscale;

--- a/source/net_vcr.h
+++ b/source/net_vcr.h
@@ -17,7 +17,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
-// net_vcr.h
+// net_vcr.
+
+#include "nzportable_def.h"
 
 #define VCR_OP_CONNECT					1
 #define VCR_OP_GETMESSAGE				2

--- a/source/nzportable_def.h
+++ b/source/nzportable_def.h
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // nzportable_def.h -- primary header for client
 
 //#define	GLTEST			// experimental stuff
+#pragma once
 
 #ifndef PLATFORM_DIRECTORY
 #error "Unknown platform! (Please build with -DPLATFORM_DIRECTORY='your_platform')"

--- a/source/pr_cmds.c
+++ b/source/pr_cmds.c
@@ -176,7 +176,7 @@ void SetMinMaxSize (edict_t *e, float *min, float *max, qboolean rotate)
 	// find min / max for rotations
 		angles = e->v.angles;
 
-		a = angles[1]/180 * M_PI;
+		a = angles[1]/180 * (float)M_PI;
 
 		xvector[0] = cosf(a);
 		xvector[1] = sinf(a);
@@ -461,7 +461,7 @@ void PF_vectoyaw (void)
 		yaw = 0;
 	else
 	{
-		yaw = (int) (atan2f(value1[1], value1[0]) * 180 / M_PI);
+		yaw = (int) (atan2f(value1[1], value1[0]) * 180 / (float)M_PI);
 		if (yaw < 0)
 			yaw += 360;
 	}
@@ -495,12 +495,12 @@ void PF_vectoangles (void)
 	}
 	else
 	{
-		yaw = (int) (atan2f(value1[1], value1[0]) * 180 / M_PI);
+		yaw = (int) (atan2f(value1[1], value1[0]) * 180 / (float)M_PI);
 		if (yaw < 0)
 			yaw += 360;
 
 		forward = sqrtf (value1[0]*value1[0] + value1[1]*value1[1]);
-		pitch = (int) (atan2f(value1[2], forward) * 180 / M_PI);
+		pitch = (int) (atan2f(value1[2], forward) * 180 / (float)M_PI);
 		if (pitch < 0)
 			pitch += 360;
 	}
@@ -625,7 +625,7 @@ void PF_sound (void)
 		Sys_Error ("SV_StartSound: volume = %i", volume);
 
 	if (attenuation < 0 || attenuation > 4)
-		Sys_Error ("SV_StartSound: attenuation = %f", attenuation);
+		Sys_Error ("SV_StartSound: attenuation = %f", (double)attenuation);
 
 	if (channel < 0 || channel > 7)
 		Sys_Error ("SV_StartSound: channel = %i", channel);
@@ -1121,7 +1121,7 @@ void PF_findradius (void)
 		if (ent->v.solid == SOLID_NOT)
 			continue;
 		for (j=0 ; j<3 ; j++)
-			eorg[j] = org[j] - (ent->v.origin[j] + (ent->v.mins[j] + ent->v.maxs[j])*0.5);
+			eorg[j] = org[j] - (ent->v.origin[j] + (ent->v.mins[j] + ent->v.maxs[j])*0.5f);
 
 		if (DotProduct(eorg, eorg) > rad)
 			continue;
@@ -1154,7 +1154,7 @@ void PF_ftos (void)
 	if (v == (int)v)
 		sprintf (pr_string_temp, "%d",(int)v);
 	else
-		sprintf (pr_string_temp, "%5.1f",v);
+		sprintf (pr_string_temp, "%5.1f",(double)v);
 	G_INT(OFS_RETURN) = pr_string_temp - pr_strings;
 }
 
@@ -1167,7 +1167,8 @@ void PF_fabs (void)
 
 void PF_vtos (void)
 {
-	sprintf (pr_string_temp, "'%5.1f %5.1f %5.1f'", G_VECTOR(OFS_PARM0)[0], G_VECTOR(OFS_PARM0)[1], G_VECTOR(OFS_PARM0)[2]);
+	sprintf (pr_string_temp, "'%5.1f %5.1f %5.1f'",
+		(double)G_VECTOR(OFS_PARM0)[0], (double)G_VECTOR(OFS_PARM0)[1], (double)G_VECTOR(OFS_PARM0)[2]);
 	G_INT(OFS_RETURN) = pr_string_temp - pr_strings;
 }
 
@@ -1233,7 +1234,7 @@ string strtrim (string)
 */
 void PF_strtrim (void)
 {
-	int		offset, length;
+	int		length;
 	char	*str;
 	char 	*end;
 
@@ -1241,7 +1242,6 @@ void PF_strtrim (void)
 
 	// figure out the new start
 	while (*str == ' ' || *str == '\t' || *str == '\n' || *str == '\r') {
-		offset++;
 		str++;
 	}
 
@@ -1252,8 +1252,6 @@ void PF_strtrim (void)
 
 	length = end - str;
 
-	if (offset < 0)
-		offset = 0;
 // 2001-10-25 Enhanced temp string handling by Maddes  start
 	if (length >= PR_MAX_TEMPSTRING)
 		length = PR_MAX_TEMPSTRING-1;
@@ -1392,6 +1390,7 @@ string strtolower (string)
 void PF_strtolower(void)
 {
 	char *s;
+	int len;
 
 	s = G_STRING(OFS_PARM0);
 
@@ -1405,9 +1404,12 @@ void PF_strtolower(void)
 		strncpy(pr_string_temp, s, PR_MAX_TEMPSTRING);
 		pr_string_temp[PR_MAX_TEMPSTRING-1] = 0;
 	}
-
-	for(int i = 0; i < strlen(s); i++)
-  		pr_string_temp[i] = tolower(pr_string_temp[i]);
+	len = strlen(s);
+	for(int i = 0; i < len; i++)
+	{
+  		if (pr_string_temp[i] >= 'A' && pr_string_temp[i] <= 'Z')
+		    pr_string_temp[i] = pr_string_temp[i] - 'a'-'A'; 
+	}
 
 	G_INT(OFS_RETURN) = pr_string_temp - pr_strings;
 }
@@ -1500,7 +1502,7 @@ zombie_ai zombie_list[MaxZombies];
 void sv_way_print_sorted_open_set() {
 	Con_Printf("Sorted open-set F-scores: ");
 	for(int i = 0; i < openset_length; i++) {
-		Con_Printf("%.0f, ",waypoints[openset_waypoints[i]].f_score);
+		Con_Printf("%.0f, ",(double)waypoints[openset_waypoints[i]].f_score);
 	}
 	Con_Printf("\n");
 }
@@ -1792,7 +1794,9 @@ void Get_Waypoint_Near (void) {
 			}
 		}
 	}
-	Con_DPrintf("'%5.1f %5.1f %5.1f', %f is %f, (%i, %i)\n", waypoints[best].origin[0],waypoints[best].origin[1], waypoints[best].origin[2], best_dist, dist, i, best);
+	Con_DPrintf("'%5.1f %5.1f %5.1f', %f is %f, (%i, %i)\n",
+		(double)waypoints[best].origin[0], (double)waypoints[best].origin[1], (double)waypoints[best].origin[2],
+		(double)best_dist, (double)dist, i, best);
 	VectorCopy (waypoints[best].origin, G_VECTOR(OFS_RETURN));
 }
 
@@ -1980,7 +1984,7 @@ void Do_Pathfind (void) {
 			Con_Printf("\tWaypoint path distances: [");
 			for(i = process_list_length - 1; i >= 0; i--) {
 				float waypoint_dist = VectorDistanceSquared(zombie->v.origin, waypoints[process_list[i]].origin);
-				Con_Printf("%.2f, ", waypoint_dist);
+				Con_Printf("%.2f, ", (double)waypoint_dist);
 			}
 			Con_Printf("]\n");
 
@@ -2116,8 +2120,10 @@ void Get_Next_Waypoint (void) {
 
 	if(developer.value == 3){
 		Con_Printf("Get_Next_Waypoint for ent %d\n", entnum);
-		Con_Printf("\tEnt origin: (%f, %f, %f)\n", ent->v.origin[0], ent->v.origin[1], ent->v.origin[2]);
-		Con_Printf("\tSearch start origin: (%f, %f, %f)\n", start[0], start[1], start[2]);
+		Con_Printf("\tEnt origin: (%f, %f, %f)\n",
+			(double)ent->v.origin[0], (double)ent->v.origin[1], (double)ent->v.origin[2]);
+		Con_Printf("\tSearch start origin: (%f, %f, %f)\n",
+			(double)start[0], (double)start[1], (double)start[2]);
 	}
 
 	int zombie_idx = -1;
@@ -2354,7 +2360,7 @@ void Get_Next_Waypoint (void) {
 		// Calculate the number in [0,1] corresponding to how far along the edge we are checking
 		cur_frac = ((float) cur_frac_numerator) / (2 << i);
 		if(developer.value == 3){
-			Con_Printf("\tBinary search iter: %d/%d, frac: %f\n", i, n_iters, cur_frac);
+			Con_Printf("\tBinary search iter: %d/%d, frac: %f\n", i, n_iters, (double)cur_frac);
 		}
 		VectorLerp(edge_start, cur_frac, edge_end, cur_point);
 
@@ -2371,7 +2377,7 @@ void Get_Next_Waypoint (void) {
 
 	if(developer.value == 3){
 		Con_Printf("\tpath after binary search: (%f x between waypoints (%d,%d), then [", 
-			best_point_frac, 
+			(double)best_point_frac, 
 			edge_start_waypoint_idx, 
 			edge_end_waypoint_idx
 		);
@@ -2394,7 +2400,7 @@ void Get_Next_Waypoint (void) {
 	// ------------------------------------------------------------------------
 	if(VectorDistanceSquared(start,best_point) < 64) {
 		// If trying to walk to the next waypoint already, skip a waypoint on the path
-		if(best_point_frac >= 1.0) {
+		if(best_point_frac >= 1.0f) {
 			zombie_list[zombie_idx].pathlist_length -= 1;
 		}
 
@@ -2424,7 +2430,8 @@ void Get_Next_Waypoint (void) {
 		}
 		Con_Printf("]\n");
 
-		Con_Printf("\tFinal best point: (%f, %f, %f)\n", best_point[0], best_point[1], best_point[2]);
+		Con_Printf("\tFinal best point: (%f, %f, %f)\n",
+			(double)best_point[0], (double)best_point[1], (double)best_point[2]);
 	}
 
 	VectorCopy(best_point, G_VECTOR(OFS_RETURN));
@@ -2754,7 +2761,7 @@ void PF_walkmove (void)
 		return;
 	}
 
-	yaw = yaw*M_PI*2 / 360;
+	yaw = yaw*((float)M_PI / 180);
 
 	move[0] = cosf(yaw)*dist;
 	move[1] = sinf(yaw)*dist;
@@ -2848,9 +2855,9 @@ void PF_rint (void)
 	float	f;
 	f = G_FLOAT(OFS_PARM0);
 	if (f > 0)
-		G_FLOAT(OFS_RETURN) = (int)(f + 0.5);
+		G_FLOAT(OFS_RETURN) = (int)(f + 0.5f);
 	else
-		G_FLOAT(OFS_RETURN) = (int)(f - 0.5);
+		G_FLOAT(OFS_RETURN) = (int)(f - 0.5f);
 }
 void PF_floor (void)
 {
@@ -2971,7 +2978,7 @@ void PF_aim (void)
 			continue;	// don't aim at teammate
 		for (j=0 ; j<3 ; j++)
 			end[j] = check->v.origin[j]
-			+ 0.5*(check->v.mins[j] + check->v.maxs[j]);
+			+ 0.5f*(check->v.mins[j] + check->v.maxs[j]);
 		VectorSubtract (end, start, dir);
 		VectorNormalize (dir);
 		dist = DotProduct (dir, pr_global_struct->v_forward);

--- a/source/pr_edict.c
+++ b/source/pr_edict.c
@@ -129,7 +129,7 @@ edict_t *ED_Alloc (void)
 		e = EDICT_NUM(i);
 		// the first couple seconds of server time can involve a lot of
 		// freeing and allocating, so relax the replacement policy
-		if (e->free && ( e->freetime < 2 || sv.time - e->freetime > 0.5 ) )
+		if (e->free && ( e->freetime < 2 || (float)sv.time - e->freetime > 0.5f ) )
 		{
 			ED_ClearEdict (e);
 			return e;
@@ -343,10 +343,11 @@ char *PR_ValueString (etype_t type, eval_t *val)
 		sprintf (line, "void");
 		break;
 	case ev_float:
-		sprintf (line, "%5.1f", val->_float);
+		sprintf (line, "%5.1f", (double)val->_float);
 		break;
 	case ev_vector:
-		sprintf (line, "'%5.1f %5.1f %5.1f'", val->vector[0], val->vector[1], val->vector[2]);
+		sprintf (line, "'%5.1f %5.1f %5.1f'",
+			(double)val->vector[0], (double)val->vector[1], (double)val->vector[2]);
 		break;
 	case ev_pointer:
 		sprintf (line, "pointer");
@@ -395,10 +396,11 @@ char *PR_UglyValueString (etype_t type, eval_t *val)
 		sprintf (line, "void");
 		break;
 	case ev_float:
-		sprintf (line, "%f", val->_float);
+		sprintf (line, "%f", (double)val->_float);
 		break;
 	case ev_vector:
-		sprintf (line, "%f %f %f", val->vector[0], val->vector[1], val->vector[2]);
+		sprintf (line, "%f %f %f",
+			(double)val->vector[0], (double)val->vector[1], (double)val->vector[2]);
 		break;
 	default:
 		sprintf (line, "bad type %i", type);

--- a/source/pr_exec.c
+++ b/source/pr_exec.c
@@ -655,7 +655,7 @@ while (1)
 
 	case OP_STATE:
 		ed = PROG_TO_EDICT(pr_global_struct->self);
-		ed->v.nextthink = pr_global_struct->time + 0.1;
+		ed->v.nextthink = pr_global_struct->time + 0.1f;
 		if (a->_float != ed->v.frame)
 		{
 			ed->v.frame = a->_float;

--- a/source/snd_dma.c
+++ b/source/snd_dma.c
@@ -482,12 +482,12 @@ void SND_Spatialize(channel_t *ch)
 	lscale = SND_InverseSpatializationLScaleLUT[dot_index];
 
 // add in distance effect
-	scale = (1.0 - dist) * rscale;
+	scale = (1.0f - dist) * rscale;
 	ch->rightvol = (int) (ch->master_vol * scale);
 	if (ch->rightvol < 0)
 		ch->rightvol = 0;
 
-	scale = (1.0 - dist) * lscale;
+	scale = (1.0f - dist) * lscale;
 	ch->leftvol = (int) (ch->master_vol * scale);
 	if (ch->leftvol < 0)
 		ch->leftvol = 0;
@@ -703,13 +703,13 @@ void S_UpdateAmbientSounds (void)
 	// don't adjust volume too fast
 		if (chan->master_vol < vol)
 		{
-			chan->master_vol += host_frametime * ambient_fade.value;
+			chan->master_vol += (float)host_frametime * ambient_fade.value;
 			if (chan->master_vol > vol)
 				chan->master_vol = vol;
 		}
 		else if (chan->master_vol > vol)
 		{
-			chan->master_vol -= host_frametime * ambient_fade.value;
+			chan->master_vol -= (float)host_frametime * ambient_fade.value;
 			if (chan->master_vol < vol)
 				chan->master_vol = vol;
 		}
@@ -970,7 +970,7 @@ qboolean	volume_changed;
 void S_VolumeDown_f (void)
 {
 	//S_LocalSound ("misc/menu3.wav");
-	volume.value -= 0.1;
+	volume.value -= 0.1f;
 	volume.value = bound(0, volume.value, 1);
 	//Cvar_SetValueByRef (&volume, volume.value);
 	volume_changed = true;
@@ -979,7 +979,7 @@ void S_VolumeDown_f (void)
 void S_VolumeUp_f (void)
 {
 	//S_LocalSound ("misc/menu3.wav");
-	volume.value += 0.1;
+	volume.value += 0.1f;
 	volume.value = bound(0, volume.value, 1);
 	//Cvar_SetValueByRef (&volume, volume.value);
 	volume_changed = true;

--- a/source/sound.h
+++ b/source/sound.h
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define __SOUND__
 
 #define DEFAULT_SOUND_PACKET_VOLUME 255
-#define DEFAULT_SOUND_PACKET_ATTENUATION 1.0
+#define DEFAULT_SOUND_PACKET_ATTENUATION 1.0f
 
 typedef struct
 {

--- a/source/sv_main.c
+++ b/source/sv_main.c
@@ -128,7 +128,7 @@ void SV_StartSound (edict_t *entity, int channel, char *sample, int volume,
 		Sys_Error ("SV_StartSound: volume = %i", volume);
 
 	if (attenuation < 0 || attenuation > 4)
-		Sys_Error ("SV_StartSound: attenuation = %f", attenuation);
+		Sys_Error ("SV_StartSound: attenuation = %f", (double)attenuation);
 
 	if (channel < 0 || channel > 7)
 		Sys_Error ("SV_StartSound: channel = %i", channel);
@@ -168,7 +168,7 @@ void SV_StartSound (edict_t *entity, int channel, char *sample, int volume,
 	MSG_WriteShort (&sv.datagram, channel);
 	MSG_WriteByte (&sv.datagram, sound_num);
 	for (i=0 ; i<3 ; i++)
-		MSG_WriteCoord (&sv.datagram, entity->v.origin[i]+0.5*(entity->v.mins[i]+entity->v.maxs[i]));
+		MSG_WriteCoord (&sv.datagram, entity->v.origin[i]+0.5f*(entity->v.mins[i]+entity->v.maxs[i]));
 }
 
 /*
@@ -205,7 +205,7 @@ void SV_SendServerinfo (client_t *client)
 	else
 		MSG_WriteByte (&client->message, GAME_COOP);
 
-	sprintf (message, pr_strings+sv.edicts->v.message);
+	sprintf (message, "%s", pr_strings+sv.edicts->v.message);
 
 	MSG_WriteString (&client->message,message);
 
@@ -492,7 +492,7 @@ void SV_WriteEntitiesToClient (edict_t	*clent, sizebuf_t *msg, qboolean nomap)
 		for (i=0 ; i<3 ; i++)
 		{
 			miss = ent->v.origin[i] - ent->baseline.origin[i];
-			if ( miss < -0.1 || miss > 0.1 )
+			if ( miss < -0.1f || miss > 0.1f )
 				bits |= U_ORIGIN1<<i;
 		}
 
@@ -530,7 +530,7 @@ void SV_WriteEntitiesToClient (edict_t	*clent, sizebuf_t *msg, qboolean nomap)
 
 	{
 		//Smal Size
-		if ((val = GETEDICTFIELDVALUE(ent, eval_renderamt)) && val->_float != 255.0) // HalfLife support
+		if ((val = GETEDICTFIELDVALUE(ent, eval_renderamt)) && val->_float != 255.0f) // HalfLife support
 			 renderamt = val->_float / 255.0f;
 
 		if ((val = GETEDICTFIELDVALUE(ent, eval_rendermode)) && val->_float != 0) // HalfLife support
@@ -1164,7 +1164,7 @@ void SV_SpawnServer (char *server)
 //
 	if (coop.value)
 		Cvar_SetValue ("deathmatch", 0);
-	current_skill = (int)(skill.value + 0.5);
+	current_skill = (int)(skill.value + 0.5f);
 	if (current_skill < 0)
 		current_skill = 0;
 	if (current_skill > 3)
@@ -1500,14 +1500,14 @@ void Load_Waypoint_NZPBETA() {
 		}
 		Con_DPrintf("Waypoint (%i)\n target1: (%i, %f),\n target2: (%i, %f),\n target3: (%i, %f),\n target4: (%i, %f),\n target5: (%i, %f),\n target6: (%i, %f),\n target7: (%i, %f),\n target8: (%i, %f)\n",
 			i,
-			waypoints[i].target[0], waypoints[i].dist[0],
-			waypoints[i].target[1], waypoints[i].dist[1],
-			waypoints[i].target[2], waypoints[i].dist[2],
-			waypoints[i].target[3], waypoints[i].dist[3],
-			waypoints[i].target[4], waypoints[i].dist[4],
-			waypoints[i].target[5], waypoints[i].dist[5],
-			waypoints[i].target[6], waypoints[i].dist[6],
-			waypoints[i].target[7], waypoints[i].dist[7]
+			waypoints[i].target[0], (double)waypoints[i].dist[0],
+			waypoints[i].target[1], (double)waypoints[i].dist[1],
+			waypoints[i].target[2], (double)waypoints[i].dist[2],
+			waypoints[i].target[3], (double)waypoints[i].dist[3],
+			waypoints[i].target[4], (double)waypoints[i].dist[4],
+			waypoints[i].target[5], (double)waypoints[i].dist[5],
+			waypoints[i].target[6], (double)waypoints[i].dist[6],
+			waypoints[i].target[7], (double)waypoints[i].dist[7]
 		);
 	}
 	W_fclose(h);
@@ -1680,14 +1680,14 @@ void Load_Waypoint () {
 		}
 		Con_DPrintf("Waypoint (%i)\n target1: (%i, %f),\n target2: (%i, %f),\n target3: (%i, %f),\n target4: (%i, %f),\n target5: (%i, %f),\n target6: (%i, %f),\n target7: (%i, %f),\n target8: (%i, %f)\n",
 			i,
-			waypoints[i].target[0], waypoints[i].dist[0],
-			waypoints[i].target[1], waypoints[i].dist[1],
-			waypoints[i].target[2], waypoints[i].dist[2],
-			waypoints[i].target[3], waypoints[i].dist[3],
-			waypoints[i].target[4], waypoints[i].dist[4],
-			waypoints[i].target[5], waypoints[i].dist[5],
-			waypoints[i].target[6], waypoints[i].dist[6],
-			waypoints[i].target[7], waypoints[i].dist[7]
+			waypoints[i].target[0], (double)waypoints[i].dist[0],
+			waypoints[i].target[1], (double)waypoints[i].dist[1],
+			waypoints[i].target[2], (double)waypoints[i].dist[2],
+			waypoints[i].target[3], (double)waypoints[i].dist[3],
+			waypoints[i].target[4], (double)waypoints[i].dist[4],
+			waypoints[i].target[5], (double)waypoints[i].dist[5],
+			waypoints[i].target[6], (double)waypoints[i].dist[6],
+			waypoints[i].target[7], (double)waypoints[i].dist[7]
 		);
 	}
 	W_fclose(h);

--- a/source/sv_move.c
+++ b/source/sv_move.c
@@ -68,12 +68,12 @@ realcheck:
 	start[2] = mins[2];
 
 // the midpoint must be within 16 of the bottom
-	start[0] = stop[0] = (mins[0] + maxs[0])*0.5;
-	start[1] = stop[1] = (mins[1] + maxs[1])*0.5;
+	start[0] = stop[0] = (mins[0] + maxs[0])*0.5f;
+	start[1] = stop[1] = (mins[1] + maxs[1])*0.5f;
 	stop[2] = start[2] - 2*STEPSIZE;
 	trace = SV_Move (start, vec3_origin, vec3_origin, stop, true, ent);
 
-	if (trace.fraction == 1.0)
+	if (trace.fraction == 1.0f)
 		return false;
 	mid = bottom = trace.endpos[2];
 
@@ -86,9 +86,9 @@ realcheck:
 
 			trace = SV_Move (start, vec3_origin, vec3_origin, stop, true, ent);
 
-			if (trace.fraction != 1.0 && trace.endpos[2] > bottom)
+			if (trace.fraction != 1.0f && trace.endpos[2] > bottom)
 				bottom = trace.endpos[2];
-			if (trace.fraction == 1.0 || mid - trace.endpos[2] > STEPSIZE)
+			if (trace.fraction == 1.0f || mid - trace.endpos[2] > STEPSIZE)
 				return false;
 		}
 
@@ -240,7 +240,7 @@ qboolean SV_StepDirection (edict_t *ent, float yaw, float dist)
 	ent->v.ideal_yaw = yaw;
 	PF_changeyaw();
 
-	yaw = yaw*M_PI*2 / 360;
+	yaw = DEG2RAD(yaw);
 	move[0] = cosf(yaw)*dist;
 	move[1] = sinf(yaw)*dist;
 	move[2] = 0;
@@ -320,7 +320,7 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 	}
 
 // try other directions
-	if ( ((rand()&3) & 1) ||  abs(deltay)>abs(deltax))
+	if ( ((rand()&3) & 1) ||  fabsf(deltay)>fabsf(deltax))
 	{
 		tdir=d[1];
 		d[1]=d[2];
@@ -408,7 +408,7 @@ void SV_NewChaseDirO (edict_t *actor, vec3_t goal, float dist)
 	}
 
 // try other directions
-	if ( ((rand()&3) & 1) ||  abs(deltay)>abs(deltax))
+	if ( ((rand()&3) & 1) ||  fabsf(deltay)>fabsf(deltax))
 	{
 		tdir=d[1];
 		d[1]=d[2];

--- a/source/sv_user.c
+++ b/source/sv_user.c
@@ -62,7 +62,7 @@ void SV_SetIdealPitch (void)
 	if (!((int)sv_player->v.flags & FL_ONGROUND))
 		return;
 
-	angleval = sv_player->v.angles[YAW] * M_PI*2 / 360;
+	angleval = DEG2RAD(sv_player->v.angles[YAW]);
 	sinval = sinf(angleval);
 	cosval = cosf(angleval);
 
@@ -141,14 +141,14 @@ void SV_UserFriction (void)
 
 	trace = SV_Move (start, vec3_origin, vec3_origin, stop, true, sv_player);
 
-	if (trace.fraction == 1.0)
+	if (trace.fraction == 1.0f)
 		friction = sv_friction.value*sv_edgefriction.value;
 	else
 		friction = sv_friction.value;
 
 // apply friction
 	control = speed < sv_stopspeed.value ? sv_stopspeed.value : speed;
-	newspeed = speed - host_frametime*control*friction;
+	newspeed = speed - (float)host_frametime*control*friction;
 
 	if (newspeed < 0)
 		newspeed = 0;
@@ -196,7 +196,7 @@ void SV_Accelerate (void)
 	addspeed = wishspeed - currentspeed;
 	if (addspeed <= 0)
 		return;
-	accelspeed = sv_accelerate.value*host_frametime*wishspeed;
+	accelspeed = sv_accelerate.value*(float)host_frametime*wishspeed;
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;
 
@@ -217,7 +217,7 @@ void SV_AirAccelerate (vec3_t wishveloc)
 	if (addspeed <= 0)
 		return;
 //	accelspeed = sv_accelerate.value * host_frametime;
-	accelspeed = sv_accelerate.value*wishspeed * host_frametime;
+	accelspeed = sv_accelerate.value*wishspeed * (float)host_frametime;
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;
 
@@ -232,7 +232,7 @@ void DropPunchAngle (void)
 
 	len = VectorNormalize (sv_player->v.punchangle);
 
-	len -= 20*host_frametime;
+	len -= 20.0f*(float)host_frametime;
 	if (len < 0)
 		len = 0;
 	VectorScale (sv_player->v.punchangle, len, sv_player->v.punchangle);
@@ -269,7 +269,7 @@ void SV_WaterMove (void)
 		VectorScale (wishvel, sv_maxspeed.value/wishspeed, wishvel);
 		wishspeed = sv_maxspeed.value;
 	}
-	wishspeed *= 0.7;
+	wishspeed *= 0.7f;
 
 //
 // water friction
@@ -277,7 +277,7 @@ void SV_WaterMove (void)
 	speed = Length (velocity);
 	if (speed)
 	{
-		newspeed = speed - host_frametime * speed * sv_friction.value;
+		newspeed = speed - (float)host_frametime * speed * sv_friction.value;
 		if (newspeed < 0)
 			newspeed = 0;
 		VectorScale (velocity, newspeed/speed, velocity);
@@ -296,7 +296,7 @@ void SV_WaterMove (void)
 		return;
 
 	VectorNormalize (wishvel);
-	accelspeed = sv_accelerate.value * wishspeed * host_frametime;
+	accelspeed = sv_accelerate.value * wishspeed * (float)host_frametime;
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;
 
@@ -306,7 +306,7 @@ void SV_WaterMove (void)
 
 void SV_WaterJump (void)
 {
-	if (sv.time > sv_player->v.teleport_time
+	if ((float)sv.time > sv_player->v.teleport_time
 	|| !sv_player->v.waterlevel)
 	{
 		sv_player->v.flags = (int)sv_player->v.flags & ~FL_WATERJUMP;
@@ -335,7 +335,7 @@ void SV_AirMove (void)
 	smove = cmd.sidemove;
 
 // hack to not let you back into teleporter
-	if (sv.time < sv_player->v.teleport_time && fmove < 0)
+	if ((float)sv.time < sv_player->v.teleport_time && fmove < 0)
 		fmove = 0;
 
 	for (i=0 ; i<3 ; i++)
@@ -446,7 +446,7 @@ void SV_ReadClientMove (usercmd_t *move)
 
 // read ping time
 	host_client->ping_times[host_client->num_pings%NUM_PING_TIMES]
-		= sv.time - MSG_ReadFloat ();
+		= (float)sv.time - MSG_ReadFloat ();
 	host_client->num_pings++;
 
 // read current angles

--- a/source/view.c
+++ b/source/view.c
@@ -133,11 +133,11 @@ float V_CalcBob (float speed,float which)//0 = regular, 1 = side bobbing
 		return bob;
 
 	// Bob idle-y, instead of presenting as if in-motion.
-	if (speed < 0.1) {
+	if (speed < 0.1f) {
 		if(cl.stats[STAT_ZOOM] == 1)
-			speed = 0.05;
+			speed = 0.05f;
 		else
-			speed = 0.25;
+			speed = 0.25f;
 
 #ifdef PSP_VFPU
 
@@ -149,9 +149,9 @@ float V_CalcBob (float speed,float which)//0 = regular, 1 = side bobbing
 #else
 
 		if (which == 0)
-			bob = cl_bobup.value * 10 * speed * (sprint * sprint) * sin(cl.time * 3.25 * sprint);
+			bob = cl_bobup.value * 10 * speed * (sprint * sprint) * sinf((float)cl.time * 3.25f * sprint);
 		else
-			bob = cl_bobside.value * 50 * speed * (sprint * sprint * sprint) * sin((cl.time * sprint) - (M_PI * 0.25));
+			bob = cl_bobside.value * 50 * speed * (sprint * sprint * sprint) * sinf(((float)cl.time * sprint) - ((float)M_PI * 0.25f));
 
 #endif // PSP_VFPU
 
@@ -159,7 +159,7 @@ float V_CalcBob (float speed,float which)//0 = regular, 1 = side bobbing
 	// Normal walk/sprint bob.
 	else {
 		if(cl.stats[STAT_ZOOM] == 3)
-			sprint = 1.8; //this gets sprinting speed in comparison to walk speed per weapon
+			sprint = 1.8f; //this gets sprinting speed in comparison to walk speed per weapon
 
 		//12.048 -> 4.3 = 100 -> 36ish, so replace 100 with 36
 
@@ -173,9 +173,9 @@ float V_CalcBob (float speed,float which)//0 = regular, 1 = side bobbing
 #else
 
 		if(which == 0)
-			bob = cl_bobup.value * 36 * speed * (sprint * sprint) * sin((cl.time * 12.5 * sprint));//Pitch Bobbing 10
+			bob = cl_bobup.value * 36 * speed * (sprint * sprint) * sinf(((float)cl.time * 12.5f * sprint));//Pitch Bobbing 10
 		else if(which == 1)
-			bob = cl_bobside.value * 36 * speed * (sprint * sprint * sprint) * sin((cl.time * 6.25 * sprint) - (M_PI * 0.25));//Yaw Bobbing 5
+			bob = cl_bobside.value * 36 * speed * (sprint * sprint * sprint) * sinf(((float)cl.time * 6.25f * sprint) - ((float)M_PI * 0.25f));//Yaw Bobbing 5
 
 #endif // PSP_VFPU 
 
@@ -239,11 +239,11 @@ float V_CalcVBob(float speed, float which)
 			bob = speed * 8.6 * (1/sprint) * vfpu_sinf((cl.time * 6.25 * sprint) - (M_PI * 0.25));//5
 		#else
 		if(which == 0)
-			bob = speed * 8.6 * (1/sprint) * sin((cl.time * 12.5 * sprint));//10
+			bob = speed * 8.6f * (1/sprint) * sinf((float)cl.time * 12.5f * sprint);//10
 		else if(which == 1)
-			bob = speed * 8.6 * (1/sprint) * sin((cl.time * 6.25 * sprint) - (M_PI * 0.25));//5
+			bob = speed * 8.6f * (1/sprint) * sinf(((float)cl.time * 6.25f * sprint) - ((float)M_PI * 0.25f));//5
 		else if(which == 2)
-			bob = speed * 8.6 * (1/sprint) * sin((cl.time * 6.25 * sprint) - (M_PI * 0.25));//5
+			bob = speed * 8.6f * (1/sprint) * sinf(((float)cl.time * 6.25f * sprint) - ((float)M_PI * 0.25f));//5
 		#endif
 	}
 	else
@@ -257,21 +257,21 @@ float V_CalcVBob(float speed, float which)
 			bob = speed * 8.6 * (1/sprint) * vfpu_cosf((cl.time * 6.25 * sprint));
 		#else
 		if(which == 0)
-			bob = speed * 8.6 * (1/sprint) * cos((cl.time * 6.25 * sprint));
+			bob = speed * 8.6f * (1/sprint) * cosf((float)cl.time * 6.25f * sprint);
 		else if(which == 1)
-			bob = speed * 8.6 * (1/sprint) * cos((cl.time * 12.5 * sprint));
+			bob = speed * 8.6f * (1/sprint) * cosf((float)cl.time * 12.5f * sprint);
 		else if(which == 2)
-			bob = speed * 8.6 * (1/sprint) * cos((cl.time * 6.25 * sprint));
+			bob = speed * 8.6f * (1/sprint) * cosf((float)cl.time * 6.25f * sprint);
 		#endif
 	}
 
 
-	if(speed > 0.1 && which == 0)
+	if(speed > 0.1f && which == 0)
 	{
 		#ifdef PSP_VFPU
 		if(canStep && vfpu_sinf(cl.time * 12.5 * sprint) < -0.8)
 		#else
-		if(canStep && sin(cl.time * 12.5 * sprint) < -0.8)
+		if(canStep && sinf((float)cl.time * 12.5f * sprint) < -0.8f)
 		#endif
 		{
 			PlayStepSound();
@@ -280,7 +280,7 @@ float V_CalcVBob(float speed, float which)
 		#ifdef PSP_VFPU
 		if(vfpu_sinf(cl.time * 12.5 * sprint) > 0.9)
 		#else
-		if(sin(cl.time * 12.5 * sprint) > 0.9)
+		if(sinf((float)cl.time * 12.5f * sprint) > 0.9f)
 		#endif
 		{
 			canStep = 1;
@@ -349,7 +349,7 @@ void V_DriftPitch (void)
 		if ( fabsf(cl.cmd.forwardmove) < cl_forwardspeed)
 			cl.driftmove = 0;
 		else
-			cl.driftmove += host_frametime;
+			cl.driftmove += (float)host_frametime;
 
 		if ( cl.driftmove > v_centermove.value)
 		{
@@ -366,8 +366,8 @@ void V_DriftPitch (void)
 		return;
 	}
 
-	move = host_frametime * cl.pitchvel;
-	cl.pitchvel += host_frametime * v_centerspeed.value;
+	move = (float)host_frametime * cl.pitchvel;
+	cl.pitchvel += (float)host_frametime * v_centerspeed.value;
 
 //Con_Printf ("move: %f (%f)\n", move, host_frametime);
 
@@ -420,7 +420,7 @@ void BuildGammaTable (float g)
 {
 	int		i, inf;
 
-	if (g == 1.0)
+	if (g == 1.0f)
 	{
 		for (i=0 ; i<256 ; i++)
 			gammatable[i] = i;
@@ -429,7 +429,7 @@ void BuildGammaTable (float g)
 
 	for (i=0 ; i<256 ; i++)
 	{
-		inf = 255 * powf ( (i+0.5f)/255.5f , g ) + 0.5;
+		inf = 255 * powf ( (i+0.5f)/255.5f , g ) + 0.5f;
 		if (inf < 0)
 			inf = 0;
 		if (inf > 255)
@@ -604,9 +604,9 @@ void V_CalcBlend (void)
 		b = b*(1-a2) + cl.cshifts[j].destcolor[2]*a2;
 	}
 
-	v_blend[0] = r/255.0;
-	v_blend[1] = g/255.0;
-	v_blend[2] = b/255.0;
+	v_blend[0] = r/255.0f;
+	v_blend[1] = g/255.0f;
+	v_blend[2] = b/255.0f;
 	v_blend[3] = a;
 	if (v_blend[3] > 1)
 		v_blend[3] = 1;
@@ -752,12 +752,12 @@ void CalcGunAngle (void)
 	yaw = r_refdef.viewangles[YAW];
 	pitch = -r_refdef.viewangles[PITCH];
 
-	yaw = angledelta(yaw - r_refdef.viewangles[YAW]) * 0.4;
+	yaw = angledelta(yaw - r_refdef.viewangles[YAW]) * 0.4f;
 	if (yaw > 10)
 		yaw = 10;
 	if (yaw < -10)
 		yaw = -10;
-	pitch = angledelta(-pitch - r_refdef.viewangles[PITCH]) * 0.4;
+	pitch = angledelta(-pitch - r_refdef.viewangles[PITCH]) * 0.4f;
 	if (pitch > 10)
 		pitch = 10;
 	if (pitch < -10)
@@ -797,20 +797,20 @@ void CalcGunAngle (void)
 
 	float side;
 	side = V_CalcRoll (cl_entities[cl.viewentity].angles, cl.velocity);
-	cl.viewent.angles[ROLL] = angledelta(cl.viewent.angles[ROLL] - ((cl.viewent.angles[ROLL] - (side * 5)) * 0.5));
+	cl.viewent.angles[ROLL] = angledelta(cl.viewent.angles[ROLL] - ((cl.viewent.angles[ROLL] - (side * 5)) * 0.5f));
 
 #ifndef __WII__
 	//^^^ Model swaying
 	if(cl.stats[STAT_ZOOM] == 1)
 	{
-		cl.viewent.angles[YAW] = (r_refdef.viewangles[YAW] + yaw) - (angledelta((r_refdef.viewangles[YAW] + yaw) - OldYawTheta ) * 0.3);//0.6
+		cl.viewent.angles[YAW] = (r_refdef.viewangles[YAW] + yaw) - (angledelta((r_refdef.viewangles[YAW] + yaw) - OldYawTheta ) * 0.3f);//0.6
 	}
 	else
 	{
-		cl.viewent.angles[YAW] = (r_refdef.viewangles[YAW] + yaw) - (angledelta((r_refdef.viewangles[YAW] + yaw) - OldYawTheta ) * 0.6);//0.6
+		cl.viewent.angles[YAW] = (r_refdef.viewangles[YAW] + yaw) - (angledelta((r_refdef.viewangles[YAW] + yaw) - OldYawTheta ) * 0.6f);//0.6
 	}
 
-	cl.viewent.angles[PITCH] = -1 * ((r_refdef.viewangles[PITCH] + pitch) - (angledelta((r_refdef.viewangles[PITCH] + pitch) + OldPitchTheta ) * 0.2));
+	cl.viewent.angles[PITCH] = -1 * ((r_refdef.viewangles[PITCH] + pitch) - (angledelta((r_refdef.viewangles[PITCH] + pitch) + OldPitchTheta ) * 0.2f));
 
 	//cl.viewent.angles[PITCH] = - (r_refdef.viewangles[PITCH] + pitch);
 #else
@@ -864,9 +864,9 @@ void CalcGunAngle (void)
 	OldYawTheta = cl.viewent.angles[YAW];
 	OldPitchTheta = cl.viewent.angles[PITCH];
 	//readd this
-	cl.viewent2.angles[ROLL] = cl.viewent.angles[ROLL] -= v_idlescale.value * sinf(cl.time*v_iroll_cycle.value * 2) * v_iroll_level.value;
-	cl.viewent2.angles[PITCH] = cl.viewent.angles[PITCH] -= v_idlescale.value * sinf(cl.time*v_ipitch_cycle.value * 2) * v_ipitch_level.value;
-	cl.viewent2.angles[YAW] = cl.viewent.angles[YAW] -= v_idlescale.value * sinf(cl.time*v_iyaw_cycle.value * 2) * v_iyaw_level.value;
+	cl.viewent2.angles[ROLL] = cl.viewent.angles[ROLL] -= v_idlescale.value * sinf((float)cl.time*v_iroll_cycle.value * 2) * v_iroll_level.value;
+	cl.viewent2.angles[PITCH] = cl.viewent.angles[PITCH] -= v_idlescale.value * sinf((float)cl.time*v_ipitch_cycle.value * 2) * v_ipitch_level.value;
+	cl.viewent2.angles[YAW] = cl.viewent.angles[YAW] -= v_idlescale.value * sinf((float)cl.time*v_iyaw_cycle.value * 2) * v_iyaw_level.value;
 
 	//Evaluating total offset
 		CWeaponRot[PITCH] -= cl.viewent.angles[PITCH];
@@ -912,9 +912,9 @@ Idle swaying
 */
 void V_AddIdle (void)
 {
-	r_refdef.viewangles[ROLL] += v_idlescale.value * sinf(cl.time*v_iroll_cycle.value) * v_iroll_level.value;
-	r_refdef.viewangles[PITCH] += v_idlescale.value * sinf(cl.time*v_ipitch_cycle.value) * v_ipitch_level.value;
-	r_refdef.viewangles[YAW] += v_idlescale.value * sinf(cl.time*v_iyaw_cycle.value) * v_iyaw_level.value;
+	r_refdef.viewangles[ROLL] += v_idlescale.value * sinf((float)cl.time*v_iroll_cycle.value) * v_iroll_level.value;
+	r_refdef.viewangles[PITCH] += v_idlescale.value * sinf((float)cl.time*v_ipitch_cycle.value) * v_ipitch_level.value;
+	r_refdef.viewangles[YAW] += v_idlescale.value * sinf((float)cl.time*v_iyaw_cycle.value) * v_iyaw_level.value;
 }
 
 
@@ -936,7 +936,7 @@ void V_CalcViewRoll (void)
 	{
 		r_refdef.viewangles[ROLL] += v_dmg_time/v_kicktime.value*v_dmg_roll;
 		r_refdef.viewangles[PITCH] += v_dmg_time/v_kicktime.value*v_dmg_pitch;
-		v_dmg_time -= host_frametime;
+		v_dmg_time -= (float)host_frametime;
 	}
 
 
@@ -996,7 +996,7 @@ void DropRecoilKick (void)
 	len = VectorNormalize (cl.gun_kick);
 
 	//Con_Printf ("len = %f\n",len);
-	len = len - 5*host_frametime;
+	len = len - 5*(float)host_frametime;
 	if (len < 0)
 		len = 0;
 	VectorScale (cl.gun_kick, len, cl.gun_kick);
@@ -1037,9 +1037,9 @@ void V_CalcRefdef (void)
 // never let it sit exactly on a node line, because a water plane can
 // dissapear when viewed with the eye exactly on it.
 // the server protocol only specifies to 1/16 pixel, so add 1/32 in each axis
-	r_refdef.vieworg[0] += 1.0/32;
-	r_refdef.vieworg[1] += 1.0/32;
-	r_refdef.vieworg[2] += 1.0/32;
+	r_refdef.vieworg[0] += 1.0f/32;
+	r_refdef.vieworg[1] += 1.0f/32;
+	r_refdef.vieworg[2] += 1.0f/32;
 
 	VectorCopy (cl.viewangles, r_refdef.viewangles);
 	V_CalcViewRoll ();
@@ -1089,7 +1089,7 @@ void V_CalcRefdef (void)
 		}
 	}
 
-	cVerticalOffset += (VerticalOffset - cVerticalOffset) * 0.3;
+	cVerticalOffset += (VerticalOffset - cVerticalOffset) * 0.3f;
 
 	temp_up[0] *= cVerticalOffset;
 	temp_up[1] *= cVerticalOffset;
@@ -1126,9 +1126,9 @@ void V_CalcRefdef (void)
 		ADSOffset[2] = 0;
 	}
 	//Side offset
-	cADSOfs [0] += (ADSOffset[0] - cADSOfs[0]) * 0.25;
-	cADSOfs [1] += (ADSOffset[1] - cADSOfs[1]) * 0.25;
-	cADSOfs [2] += (ADSOffset[2] - cADSOfs[2]) * 0.25;
+	cADSOfs [0] += (ADSOffset[0] - cADSOfs[0]) * 0.25f;
+	cADSOfs [1] += (ADSOffset[1] - cADSOfs[1]) * 0.25f;
+	cADSOfs [2] += (ADSOffset[2] - cADSOfs[2]) * 0.25f;
 
 	temp_right[0] *= cADSOfs[0];
 	temp_right[1] *= cADSOfs[0];
@@ -1146,7 +1146,7 @@ void V_CalcRefdef (void)
 	view->origin[1] +=(temp_forward[1] + temp_right[1] + temp_up[1]);
 	view->origin[2] +=(temp_forward[2] + temp_right[2] + temp_up[2]);
 
-	float speed = (0.2 + sqrt((cl.velocity[0] * cl.velocity[0])	+	(cl.velocity[1] * cl.velocity[1])));
+	float speed = (0.2f + sqrtf((cl.velocity[0] * cl.velocity[0])	+	(cl.velocity[1] * cl.velocity[1])));
 	speed = speed/190;
 
 	float		bob, bobside = 0;
@@ -1160,8 +1160,8 @@ void V_CalcRefdef (void)
 	{
 		if (cl_sidebobbing.value)
 		{
-			view->origin[i] += right[i]*bobside*0.4;
-			view->origin[i] += up[i]*bob*0.5;
+			view->origin[i] += right[i]*bobside*0.4f;
+			view->origin[i] += up[i]*bob*0.5f;
 //			view2->origin[i] += right[i]*bobside*0.2;
 //			view2->origin[i] += up[i]*bob*0.2;
 //			mz->origin[i] += right[i]*bobside*0.2;
@@ -1169,7 +1169,7 @@ void V_CalcRefdef (void)
 		}
 		else
 		{
-			view->origin[i] += forward[i]*bob*0.4;
+			view->origin[i] += forward[i]*bob*0.4f;
 //			view2->origin[i] += forward[i]*bob*0.4;
 //			mz->origin[i] += forward[i]*bob*0.4;
 		}
@@ -1186,9 +1186,9 @@ void V_CalcRefdef (void)
 	vbob[1] = V_CalcVBob(speed,1) * cl_bob.value * 50;
 	vbob[2] = V_CalcVBob(speed,2) * cl_bob.value * 50;
 
-	r_refdef.viewangles[YAW] = angledelta(r_refdef.viewangles[YAW] + (vbob[0] * 0.1));
-	r_refdef.viewangles[PITCH] = angledelta(r_refdef.viewangles[PITCH] + (vbob[1] * 0.1));
-	r_refdef.viewangles[ROLL] = anglemod(r_refdef.viewangles[ROLL] + (vbob[2] * 0.05));
+	r_refdef.viewangles[YAW] = angledelta(r_refdef.viewangles[YAW] + (vbob[0] * 0.1f));
+	r_refdef.viewangles[PITCH] = angledelta(r_refdef.viewangles[PITCH] + (vbob[1] * 0.1f));
+	r_refdef.viewangles[ROLL] = anglemod(r_refdef.viewangles[ROLL] + (vbob[2] * 0.05f));
 
 
 
@@ -1213,9 +1213,9 @@ void V_CalcRefdef (void)
 // set up the refresh position
 
 	//blubs's punchangle interpolation
-	lastPunchAngle[0] += (cl.punchangle[0] - lastPunchAngle[0]) * 0.5;
-	lastPunchAngle[1] += (cl.punchangle[1] - lastPunchAngle[1]) * 0.5;
-	lastPunchAngle[2] += (cl.punchangle[2] - lastPunchAngle[2]) * 0.5;
+	lastPunchAngle[0] += (cl.punchangle[0] - lastPunchAngle[0]) * 0.5f;
+	lastPunchAngle[1] += (cl.punchangle[1] - lastPunchAngle[1]) * 0.5f;
+	lastPunchAngle[2] += (cl.punchangle[2] - lastPunchAngle[2]) * 0.5f;
 	//VectorCopy(cl.punchangle,lastPunchAngle);
 
 	VectorAdd (r_refdef.viewangles, lastPunchAngle, r_refdef.viewangles);
@@ -1635,7 +1635,7 @@ void V_RenderView (void)
 		int		i;
 		
 		vid.rowbytes <<= 1;
-		vid.aspect *= 0.5;
+		vid.aspect *= 0.5f;
 		
 		r_refdef.viewangles[YAW] -= lcd_yaw.value;
 		for (i=0 ; i<3 ; i++)

--- a/source/world.c
+++ b/source/world.c
@@ -251,7 +251,7 @@ areanode_t *SV_CreateAreaNode (int depth, vec3_t mins, vec3_t maxs)
 	else
 		anode->axis = 1;
 
-	anode->dist = 0.5 * (maxs[anode->axis] + mins[anode->axis]);
+	anode->dist = 0.5f * (maxs[anode->axis] + mins[anode->axis]);
 	VectorCopy (mins, mins1);
 	VectorCopy (mins, mins2);
 	VectorCopy (maxs, maxs1);
@@ -696,8 +696,8 @@ reenter:
 	}
 	else
 	{
-		t1 = DoublePrecisionDotProduct (plane->normal, p1) - plane->dist;
-		t2 = DoublePrecisionDotProduct (plane->normal, p2) - plane->dist;
+		t1 = DoublePrecisionDotProduct (plane->normal, p1) - (double)plane->dist;
+		t2 = DoublePrecisionDotProduct (plane->normal, p2) - (double)plane->dist;
 	}
 
 	/*if its completely on one side, resume on that side*/
@@ -744,19 +744,19 @@ reenter:
 		/*we impacted the back of the node, so flip the plane*/
 		trace->plane.dist = -plane->dist;
 		VectorNegate(plane->normal, trace->plane.normal);
-		midf = (t1 + DIST_EPSILON) / (t1 - t2);
+		midf = (t1 + (float)DIST_EPSILON) / (t1 - t2);
 	}
 	else
 	{
 		/*we impacted the front of the node*/
 		trace->plane.dist = plane->dist;
 		VectorCopy(plane->normal, trace->plane.normal);
-		midf = (t1 - DIST_EPSILON) / (t1 - t2);
+		midf = (t1 - (float)DIST_EPSILON) / (t1 - t2);
 	}
 
-	t1 = DoublePrecisionDotProduct (trace->plane.normal, ctx->start) - trace->plane.dist;
-	t2 = DoublePrecisionDotProduct (trace->plane.normal, ctx->end) - trace->plane.dist;
-	midf = (t1 - DIST_EPSILON) / (t1 - t2);
+	t1 = DoublePrecisionDotProduct (trace->plane.normal, ctx->start) - (double)trace->plane.dist;
+	t2 = DoublePrecisionDotProduct (trace->plane.normal, ctx->end) - (double)trace->plane.dist;
+	midf = (t1 - (float)DIST_EPSILON) / (t1 - t2);
 
 	midf = CLAMP(0, midf, 1);
 	trace->fraction = midf;
@@ -1012,7 +1012,7 @@ void SV_ClipToLinks ( areanode_t *node, moveclip_t *clip )
 		trace.fraction < clip->trace.fraction)
 		{
 			trace.ent = touch;
-		 	if (clip->trace.startsolid)
+			if (clip->trace.startsolid)
 			{
 				clip->trace = trace;
 				clip->trace.startsolid = true;

--- a/source/zone.c
+++ b/source/zone.c
@@ -735,11 +735,10 @@ Otherwise, allocations with the same name will be totaled up before printing.
 void Hunk_Print (qboolean all)
 {
 	hunk_t	*h, *next, *endlow, *starthigh, *endhigh;
-	int		count, sum;
+	int		sum;
 	int		totalblocks;
 	char	name[HUNKNAME_LEN];
 
-	count = 0;
 	sum = 0;
 	totalblocks = 0;
 
@@ -779,7 +778,6 @@ void Hunk_Print (qboolean all)
 			Sys_Error ("Hunk_Check: bad size");
 
 		next = (hunk_t *)((byte *)h+h->size);
-		count++;
 		totalblocks++;
 		sum += h->size;
 
@@ -798,7 +796,6 @@ void Hunk_Print (qboolean all)
 		{
 			if (!all)
 				Con_Printf ("          :%8i %8s (TOTAL)\n",sum, name);
-			count = 0;
 			sum = 0;
 		}
 
@@ -1224,7 +1221,7 @@ Cache_Report
 */
 void Cache_Report (void)
 {
-	Con_DPrintf ("%4.1f megabyte data cache\n", (hunk_size - hunk_high_used - hunk_low_used) / (float)(1024*1024) );
+	Con_DPrintf ("%4.1f megabyte data cache\n", (double)(hunk_size - hunk_high_used - hunk_low_used) / (double)(1024*1024) );
 }
 
 /*


### PR DESCRIPTION
### Description of Changes
---
Most of the changes in this PR are for making vril compile with -Werror=double-promotion
This involves changing the suffix of some double literals to make them floats, calling sin/cos***f*** instead of sin/cos, casting doubles to floats for operations when the result gets assigned to floats, among others.

I cleaned up a few instances where warnings were previously erroneously being suppressed by fixing them properly.

I played a few rounds of Nacht Der Untoten on O2DS see if I broke anything, and it was fine.

### Visual Sample
There are no visual changes

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage