### PR TITLE
GLOBAL: Fix regression in mathlib due to incorrect roll constant

### DIFF
--- a/source/mathlib.c
+++ b/source/mathlib.c
@@ -531,7 +531,7 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 	sy = sinf(angle);
 	cy = cosf(angle);
 	#endif
-	angle = angles[PITCH] * ((float)M_PI / 180);
+	angle = angles[PITCH] * ((float)M_PI / 180.0f);
 	#ifdef PSP_VFPU
 	sp = vfpu_sinf(angle);
 	cp = vfpu_cosf(angle);
@@ -539,7 +539,7 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 	sp = sinf(angle);
 	cp = cosf(angle);
 	#endif
-	angle = angles[ROLL] * ((float)M_PI / 360);
+	angle = angles[ROLL] * ((float)M_PI / 180.0f);
 	#ifdef PSP_VFPU
 	sr = vfpu_sinf(angle);
 	cr = vfpu_cosf(angle);


### PR DESCRIPTION
### Description of Changes
---
Fixes a regression in mathlib's `AngleVectors` where roll calculation kept a 360 divisor instead of an expected 180.

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
