### PR TITLE
PSP: Add support for right analog stick on PSVITA/PSP GO

### DIFF
--- a/source/cl_main.c
+++ b/source/cl_main.c
@@ -54,9 +54,7 @@ cvar_t	m_forward = {"m_forward","1", true};
 cvar_t	m_side = {"m_side","0.8", true};
 
 cvar_t	in_disable_analog = {"in_disable_analog", "0", true};
-cvar_t	in_analog_strafe = {"in_analog_strafe", "0", true};
-cvar_t  in_x_axis_adjust = {"in_x_axis_adjust", "0", true};
-cvar_t  in_y_axis_adjust = {"in_y_axis_adjust", "0", true};
+cvar_t	in_anub_mode = {"in_anub_mode", "0", true};
 
 //=================================================//
 modelindex_t		cl_modelindex[NUM_MODELINDEX]; //
@@ -1088,9 +1086,7 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&in_tolerance);
 	Cvar_RegisterVariable (&in_acceleration);
 	Cvar_RegisterVariable (&in_disable_analog);
-	Cvar_RegisterVariable (&in_analog_strafe);
-	Cvar_RegisterVariable (&in_x_axis_adjust);
-	Cvar_RegisterVariable (&in_y_axis_adjust);
+	Cvar_RegisterVariable (&in_anub_mode);
 	
 #ifdef __WII__
 	Cvar_RegisterVariable (&ads_center);

--- a/source/platform/ctr/client.h
+++ b/source/platform/ctr/client.h
@@ -282,7 +282,6 @@ extern	cvar_t	sensitivity;
 extern	cvar_t	in_tolerance;
 extern	cvar_t	in_acceleration;
 extern 	cvar_t 	in_aimassist;
-extern 	cvar_t	in_analog_strafe;
 
 extern	cvar_t	m_pitch;
 extern	cvar_t	m_yaw;

--- a/source/platform/ctr/in_ctr.c
+++ b/source/platform/ctr/in_ctr.c
@@ -29,18 +29,11 @@ extern bool new3ds_flag;
 extern bool croshhairmoving;
 extern float crosshair_opacity;
 
-extern cvar_t in_analog_strafe;
-extern cvar_t in_x_axis_adjust;
-extern cvar_t in_y_axis_adjust;
 extern cvar_t in_mlook; //Heffo - mlook cvar
-
-cvar_t in_anub_mode = {"in_anub_mode", "0", true};
+extern cvar_t in_anub_mode;
 
 void IN_Init (void)
 {
-	Cvar_RegisterVariable (&in_analog_strafe);
-	Cvar_RegisterVariable (&in_anub_mode);
-
 	if (new3ds_flag) {
 		Cvar_SetValue("in_anub_mode", 1);
 	}

--- a/source/platform/ctr/menu.c
+++ b/source/platform/ctr/menu.c
@@ -23,9 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t	r_wateralpha;
 extern cvar_t	r_vsync;
 extern cvar_t	in_disable_analog;
-extern cvar_t	in_analog_strafe;
-extern cvar_t	in_x_axis_adjust;
-extern cvar_t	in_y_axis_adjust;
+extern cvar_t	in_anub_mode;
 extern cvar_t	crosshair;
 extern cvar_t	r_dithering;
 //extern cvar_t	r_retro;

--- a/source/platform/psp/client.h
+++ b/source/platform/psp/client.h
@@ -283,9 +283,7 @@ extern	cvar_t	lookstrafe;
 extern	cvar_t	in_sensitivity;
 extern	cvar_t	in_tolerance;
 extern	cvar_t	in_acceleration;
-extern  cvar_t  in_analog_strafe;
-extern  cvar_t  in_x_axis_adjust;
-extern  cvar_t  in_y_axis_adjust;
+extern  cvar_t  in_anub_mode;
 
 extern	cvar_t	in_mlook; //Heffo - mlook cvar
 

--- a/source/platform/psp/menu.c
+++ b/source/platform/psp/menu.c
@@ -34,7 +34,7 @@ extern cvar_t	accesspoint;
 extern cvar_t	r_wateralpha;
 extern cvar_t	r_vsync;
 extern cvar_t	in_disable_analog;
-extern cvar_t	in_analog_strafe;
+extern cvar_t	in_anub_mode;
 extern cvar_t	in_x_axis_adjust;
 extern cvar_t	in_y_axis_adjust;
 extern cvar_t	crosshair;
@@ -2689,7 +2689,7 @@ void M_AdjustSliders (int dir, int m_submenu, int options_cursor)
 				break;
 			case OPT_MOUSELOOK:
 				Cvar_SetValue ("in_mlook", !in_mlook.value);
-				Cvar_SetValue ("in_analog_strafe", !in_analog_strafe.value);
+				Cvar_SetValue ("in_anub_mode", !in_anub_mode.value);
 				break;
         }
     }
@@ -3081,14 +3081,14 @@ void M_Gameplay_Draw (void)
 
 	// A-Nub Mode
 	if (gameplay_cursor == OPT_MOUSELOOK) {
-		Draw_ColoredString(10, 105, "A-Nub Mode", 255, 0, 0, 255, 1);
+		Draw_ColoredString(10, 105, "Left A-Nub Mode", 255, 0, 0, 255, 1);
 	} else {
-		Draw_ColoredString(10, 105, "A-Nub Mode", 255, 255, 255, 255, 1);
+		Draw_ColoredString(10, 105, "Left A-Nub Mode", 255, 255, 255, 255, 1);
 	}
 	if (in_mlook.value) {
-		Draw_ColoredString(225, 105, "Look", 255, 255, 255, 255, 1);
+		Draw_ColoredString(225, 105, "Look (Right is Move)", 255, 255, 255, 255, 1);
 	} else {
-		Draw_ColoredString(225, 105, "Move (Buggy!)", 255, 255, 255, 255, 1);
+		Draw_ColoredString(225, 105, "Move (Right is Look)", 255, 255, 255, 255, 1);
 	}
 
 	// Back
@@ -3110,7 +3110,7 @@ void M_Gameplay_Draw (void)
 			Draw_ColoredString(10, 230, "Adjust Look Sensitivity.", 255, 255, 255, 255, 1);
 			break;
 		case OPT_IN_ACCELERATION:
-			Draw_ColoredString(10, 230, "Adjust Acceleration when A-Nub Mode is set to 'Look'.", 255, 255, 255, 255, 1);
+			Draw_ColoredString(10, 230, "Adjust Acceleration for A-Nub that is set to 'Look'.", 255, 255, 255, 255, 1);
 			break;
 		case OPT_INVMOUSE:
 			Draw_ColoredString(10, 230, "Invert A-Nub Look.", 255, 255, 255, 255, 1);
@@ -3119,7 +3119,7 @@ void M_Gameplay_Draw (void)
 			Draw_ColoredString(10, 230, "Adjust how Tolerant the A-Nub is to change.", 255, 255, 255, 255, 1);
 			break;
 		case OPT_MOUSELOOK:
-			Draw_ColoredString(10, 230, "Toggle whether to use the A-Nub for Look or Movement.", 255, 255, 255, 255, 1);
+			Draw_ColoredString(10, 230, "Toggle whether to use the Left A-Nub for Look or Movement.", 255, 255, 255, 255, 1);
 			break;
 	}
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds support for the right analog nub on PlayStation Portable. This is applicable in the following contexts:
- When running on Adrenaline, on PS VITA
- When using a DualShock 3 on PSP GO
- PPSSPP
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
https://github.com/user-attachments/assets/4caf4535-4c52-4abe-9f50-e60fccb6fb07

<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
