### PR TITLE
3DS: Fix build with GCC 15

### DIFF
--- a/source/platform/ctr/common.h
+++ b/source/platform/ctr/common.h
@@ -37,7 +37,7 @@ typedef unsigned char 		byte;
 #undef true
 #undef false
 
-typedef enum {false, true}	qboolean;
+typedef _Bool qboolean;
 
 //============================================================================
 

--- a/source/platform/ctr/gl/gl_mesh.c
+++ b/source/platform/ctr/gl/gl_mesh.c
@@ -32,7 +32,7 @@ ALIAS MODEL DISPLAY LIST GENERATION
 model_t		*aliasmodel;
 aliashdr_t	*paliashdr;
 
-qboolean	used[8192];
+int32_t 	used[8192];
 
 // the command list holds counts and s/t values that are valid for
 // every frame


### PR DESCRIPTION
### Description of Changes
---
devkitARM recently updated to GCC 15, which caused some build errors with vril.

```c
In file included from /home/peter/vril-engine/source/nzportable_def.h:224,
                 from /home/peter/vril-engine/source/system.c:25:
/home/peter/vril-engine/source/platform/ctr/common.h:40:15: error: cannot use keyword 'false' as enumeration constant
   40 | typedef enum {false, true}      qboolean;
      |               ^~~~~
/home/peter/vril-engine/source/platform/ctr/common.h:40:15: note: 'false' is a keyword with '-std=c23' onwards
```

This one is caused by GCC 15 switching its default C standard to C23. Perhaps we want to force it to C99 for the time being but that is for another PR, I still think these changes are desired regardless.

This change then uncovered two warnings:
```
/home/peter/vril-engine/source/platform/ctr/gl/gl_mesh.c: In function 'StripLength':
/home/peter/vril-engine/source/platform/ctr/gl/gl_mesh.c:116:29: warning: comparison of constant '2' with boolean expression is always false [-Wbool-compare]
  116 |                 if (used[j] == 2)
      |                             ^~
/home/peter/vril-engine/source/platform/ctr/gl/gl_mesh.c: In function 'FanLength':
/home/peter/vril-engine/source/platform/ctr/gl/gl_mesh.c:183:29: warning: comparison of constant '2' with boolean expression is always false [-Wbool-compare]
  183 |                 if (used[j] == 2)
      |                             ^~
```

Which is what the second hunk is about. Both of these functions assign "2" to an array of "qboolean" and check for it later as some sort of sentinel value. This works because the type of the enum is int anyway, but I think changing the type of the variable is a better idea than having some sort of "3 state boolean" in this code.

### Checklist
---

- [ ] I have thoroughly tested my changes to the best of my ability
- [ ] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
