### PR TITLE
3DS: Specify C standard explicitly

### DIFF
--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -26,7 +26,7 @@ APP_DESCRIPTION := Call of Duty Zombies remake
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -Wdouble-promotion -O3 -mword-relocations \
+CFLAGS	:=	-g -Wall -Wdouble-promotion -std=gnu99 -O3 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 


### PR DESCRIPTION
### Description of Changes
Add -std=gnu99 to the CFLAGS. GCC 15 changed the default C standard from C17 to C23, which broke the build.
It's best to specify it explicitly so we don't have those problems in the future.

see #77 for some of the errors.

-std=gnu99 is used instead of c99 because it caused some further build errors for missing functions strcasecmp and strlcpy.

The PSP doesn't need this change because it uses C++.

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
