### PR TITLE
CTR: Fix type mismatch warning

### DIFF
--- a/source/cl_hud.c
+++ b/source/cl_hud.c
@@ -1309,7 +1309,7 @@ HUD_Perks
 #define 	P_DEAD 		64
 #define 	P_MULE 		128
 
-int perk_order[9];
+int perk_order[8];
 int current_perk_order;
 
 void HUD_Perks (void)


### PR DESCRIPTION
```
/home/peter/vril-engine/source/host.c:506:12: warning: type of 'perk_order' does not match original declaration [-Wlto-type-mismatch]
  506 | extern int perk_order[8];
      |            ^
/home/peter/vril-engine/source/cl_hud.c:1312:5: note: array types have different bounds
 1312 | int perk_order[9];
      |     ^
```
After reviewing this code, I have determined the correct fix is to make the length of the array 8. No code anywhere uses an index beyond 7.

### Description of Changes

Change the array length in the definition to match the declaration.

### Checklist
---

- [ ] I have thoroughly tested my changes to the best of my ability
- [ ] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
