### PR TITLE
PSP: Hack around pad.Rx/y returning 0 when stick isn't present

### DIFF
--- a/source/nzportable_def.h
+++ b/source/nzportable_def.h
@@ -45,7 +45,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __PSP__
 #define PSP_MODEL_PHAT		0
 #define PSP_MODEL_SLIM 		1
-#define PSP_MODEL_PSVITA 	2
+#define PSP_MODEL_GO		2
+#define PSP_MODEL_PSVITA 	3
+#define PSP_MODEL_PPSSPP	4
 
 extern int psp_system_model;
 #endif // __PSP__

--- a/source/platform/psp/input.cpp
+++ b/source/platform/psp/input.cpp
@@ -281,6 +281,7 @@ float IN_CalcInput(int axis, float speed, float tolerance, float acceleration) {
 
 extern cvar_t scr_fov;
 extern int original_fov, final_fov;
+bool system_has_right_stick;
 void IN_Move (usercmd_t *cmd)
 {
 	V_StopPitchDrift();
@@ -288,6 +289,10 @@ void IN_Move (usercmd_t *cmd)
 	// Read the pad state.
 	SceCtrlData pad;
 	sceCtrlPeekBufferPositive(&pad, 1);
+
+	// The right stick always returns 0 when it's not present
+	// so to make sure we don't constantly walk diagonally left, initialize to 128
+	if (!system_has_right_stick) pad.Rsrv[0] = pad.Rsrv[1] = 128;
 
 	// Convert the inputs to floats in the range [-1, 1].
 	// Implement the dead zone.

--- a/source/platform/psp/main.cpp
+++ b/source/platform/psp/main.cpp
@@ -514,6 +514,11 @@ int user_main(SceSize argc, void* argp)
 
 	psp_system_model = Sys_GetPSPModel();
 
+	extern bool system_has_right_stick;
+
+	system_has_right_stick = Sys_HasRightStick();
+
+
 	// Disable floating point exceptions.
 	// If this isn't done, Quake crashes from (presumably) divide by zero
 	// operations.
@@ -742,10 +747,32 @@ int Sys_GetPSPModel(void)
 		return PSP_MODEL_PSVITA;
 	}
 
+	// Thanks to Linblow for providing code for detecting PPSSPP
+	int res;
+	int ret = sceIoDevctl("emulator:", 3, &res, 4, NULL, 0);
+	if (ret == 0) return PSP_MODEL_PPSSPP;
+
 	int model = kuKernelGetModel();
 
 	if (model == 0)
 		return PSP_MODEL_PHAT;
+	if (model == 4)
+		return PSP_MODEL_GO;
 
 	return PSP_MODEL_SLIM;
+}
+
+bool Sys_HasRightStick(void)
+{
+	int psp_system_model = Sys_GetPSPModel();
+	if (psp_system_model == PSP_MODEL_PSVITA || psp_system_model == PSP_MODEL_PPSSPP) {
+		return true;
+	} else if (psp_system_model == PSP_MODEL_GO) {
+		SceCtrlData pad;
+		sceCtrlPeekBufferPositive(&pad, 1);
+		if (pad.Rsrv[0] != 0 && pad.Rsrv[1] != 0) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/source/platform/psp/sys.h
+++ b/source/platform/psp/sys.h
@@ -75,5 +75,7 @@ void Sys_SetFPCW (void);
 
 // returns psp model
 int Sys_GetPSPModel(void);
+// returns if the console has a right stick
+bool Sys_HasRightStick(void);
 
 void Sys_CaptureScreenshot(void);

--- a/source/platform/psp/system.cpp
+++ b/source/platform/psp/system.cpp
@@ -342,7 +342,10 @@ void Sys_PrintSystemInfo(void)
 	switch(psp_system_model) {
 		case PSP_MODEL_PHAT: Con_Printf("PSP Model: PSP-1000 model unit\n"); break;
 		case PSP_MODEL_SLIM: Con_Printf("PSP Model: PSP-SLIM model unit\n"); break;
+		case PSP_MODEL_GO: Con_Printf("PSP Model: PSP-Go model unit\n"); break;
 		case PSP_MODEL_PSVITA: Con_Printf("PSP Model: PS VITA model unit\n"); break;
+		case PSP_MODEL_PPSSPP: Con_Printf("PSP Model: PPSSPP Emulator\n"); break;
+
 		default: break;
 	}
 


### PR DESCRIPTION
On systems without a second stick, reading pad.Rx and pad.Ry always returns zero. The input code read this, and thought the stick was permanently pressed diagonally left.

So, as a hack, during setup on the PSP go, check for pad.Rx and pad.Ry being nonzero, assume there is no paired controller otherwise.

### Description of Changes
Add code to detect the PSP go and PPSSPP.

Assume PPSSPP and PSVITA always have a second stick
For the PSP go, check that pad.Rx and pad.Ry are nonzero.

### Checklist
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
