### PR TITLE
PSP: Fix corrupted palette issue on Temple and Bunker-Defense

### DIFF
--- a/source/platform/psp/gu/gu_draw.cpp
+++ b/source/platform/psp/gu/gu_draw.cpp
@@ -203,17 +203,15 @@ void GL_Bind (int texture_index)
 	// Which texture is it?
 	const gltexture_t& texture = gltextures[texture_index];
 
+	sceGuTexMode(texture.format, texture.mipmaps , 0, texture.swizzle);
 
 	// HACK HACK HACK: avoid setting this all the time
-	if (last_palette_wasnt_tx == qtrue)
+	if (texture.format == GU_PSM_T8 && last_palette_wasnt_tx) {
 		VID_SetPaletteTX();
-
-	if (texture.format == GU_PSM_T4) {
+	} else if (texture.format == GU_PSM_T4) {
 		VID_SetPalette4(texture.palette);
 	}
 
-	sceGuTexMode(texture.format, texture.mipmaps , 0, texture.swizzle);
-	
 	// Set the Texture filter.
 	if (r_retro.value)
 		sceGuTexFilter(GU_NEAREST, GU_NEAREST);

--- a/source/platform/psp/gu/gu_psp.cpp
+++ b/source/platform/psp/gu/gu_psp.cpp
@@ -133,7 +133,7 @@ void VID_SetPaletteTX()
 
 void VID_SetPalette4(unsigned char* clut4pal) {
 	sceGuClutMode(GU_PSM_8888, 0, 0xFF, 0);
-	sceKernelDcacheWritebackRange(clut4pal, sizeof(clut4pal));
+	sceKernelDcacheWritebackRange(clut4pal, 4 * 16);
 	sceGuClutLoad(2, clut4pal);
 	last_palette_wasnt_tx = qtrue;
 }


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
- Fixes https://github.com/nzp-team/nzportable/issues/404
- Do sceGuTexMode before touching the CLUT fixes issue, if we set the CLUT while we're still in DXT1 mode from sky, it messes up.
- Removed an extra quake palette set when drawing CLUT4 textures, might improve perf
- Set appropriate size for dcacheWriteback when setting CLUT4 palette 
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
(The visual big in the issue no longer happens)
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
