### PR TITLE
GLOBAL: Promote currentmag to short

### DIFF
--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -949,7 +949,7 @@ void CL_ParseClientdata (int bits)
 		cl.stats[STAT_AMMO] = i;
 	}
 
-	i = MSG_ReadByte ();
+	i = MSG_ReadShort ();
 	if (cl.stats[STAT_CURRENTMAG] != i)
 	{
 		HUD_Change_time = Sys_FloatTime() + 6;
@@ -999,7 +999,7 @@ void CL_ParseClientdata (int bits)
 	if (cl.stats[STAT_WEAPON2FRAME] != i)
 		cl.stats[STAT_WEAPON2FRAME] = i;
 
-	i = MSG_ReadByte ();
+	i = MSG_ReadShort ();
 	if (cl.stats[STAT_CURRENTMAG2] != i)
 		cl.stats[STAT_CURRENTMAG2] = i;
 }

--- a/source/sv_main.c
+++ b/source/sv_main.c
@@ -771,7 +771,7 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 	MSG_WriteShort (msg, ent->v.secondary_grenades);
 	MSG_WriteShort (msg, ent->v.health);
 	MSG_WriteShort (msg, ent->v.currentammo);
-	MSG_WriteByte (msg, ent->v.currentmag);
+	MSG_WriteShort (msg, ent->v.currentmag);
 	MSG_WriteByte (msg, ent->v.zoom);
 
 	MSG_WriteByte (msg, ent->v.weapon);
@@ -783,7 +783,7 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 	MSG_WriteShort (msg, SV_ModelIndex(pr_strings+ent->v.weapon2model));
 	MSG_WriteByte (msg, ent->v.weapon2skin);
 	MSG_WriteByte (msg, ent->v.weapon2frame);
-	MSG_WriteByte (msg, ent->v.currentmag2);
+	MSG_WriteShort (msg, ent->v.currentmag2);
 }
 
 /*


### PR DESCRIPTION
### Description of Changes
---
Promotes the current mag count (both primary and secondary) in client stats from byte to short. This fixes nzp-team/nzportable#1162.

### Visual Sample
---
![image](https://github.com/user-attachments/assets/ffdb5ee2-edfc-4ae9-849d-7803da73963f)

From nzp-team/nzportable#1162, here's the current behavior:
https://github.com/user-attachments/assets/1ace83d7-d12e-431c-9232-7ff2f1c861e4

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
