### PR TITLE
PSP: Explicitly set GNU C99; update sceGuScissor call

### DIFF
--- a/Makefile.psp
+++ b/Makefile.psp
@@ -137,6 +137,9 @@ ASFLAGS = $(CFLAGS) -c
 
 include $(PSPSDK)/lib/build.mak
 
+%.o: %.c
+	$(CC) -std=gnu99 $(CFLAGS) -c $< -o $@
+
 _build_info.h:
 	rm -rf source/_build_info.h
 	echo "#define GIT_HASH \"$(shell git rev-parse --short HEAD)$(shell git diff --quiet || echo -dirty)\"" > source/_build_info.h

--- a/source/platform/psp/gu/gu_main.cpp
+++ b/source/platform/psp/gu/gu_main.cpp
@@ -3376,7 +3376,7 @@ void R_RenderScene (void)
 		gly + (glheight >> 1) - y2 - (h >> 1), //xaa - try to skip some divides (/2) here
 		w,
 		h);
-	sceGuScissor(x, glheight - y2 - h, x + w, glheight - y2);
+	sceGuScissor(x, glheight - y2 - h, w, h);
 
     screenaspect = (float)renderrect->width/renderrect->height;
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
PSPSDK has updated to GCC 15, so by default is compiling with newer C standards. Similar to #78 this PR ensures we explicitly use C99. It also updates the use of `sceGuScissor` to reflect the changes found in https://github.com/pspdev/pspsdk/pull/295
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
