### PR TITLE
TNS: Fix config file and nzp.rc loading

### DIFF
--- a/source/cl_hud.c
+++ b/source/cl_hud.c
@@ -247,7 +247,7 @@ void HUD_Init (void)
 
 #endif // __PSP__, __3DS__, __WII__, __NSPIRE__
 
-fx_blood_lu = Draw_CachePic ("gfx/hud/blood");
+	fx_blood_lu = Draw_CachePic ("gfx/hud/blood");
 
 #ifdef __WII__
 	Cmd_AddCommand ("+showscores", HUD_Scoreboard_Down);

--- a/source/cmd.c
+++ b/source/cmd.c
@@ -297,6 +297,15 @@ void Cmd_Exec_f (void)
 
 	mark = Hunk_LowMark ();
 	f = (char *)COM_LoadHunkFile (va("%s%s%s", FILE_SPECIAL_PREFIX, Cmd_Argv(1), FILE_SPECIAL_SUFFIX));
+
+	if (!f)
+	{
+		// Try again without the special prefix and suffix. This is needed for stuff like 
+		// nzp.rc and config.cfg inside of a PAK file. But we for sure should prefer the stuff
+		// outside of a PAK file first. 
+		f = (char *)COM_LoadHunkFile (Cmd_Argv(1));
+	}
+
 	if (!f)
 	{
 		Con_Printf ("couldn't exec %s\n",Cmd_Argv(1));


### PR DESCRIPTION
### Description of Changes
This Pull Request adds a backup loading strategy for executing files through the console. This is done in order to add support for loading `nzp.rc` (and thus other config files) inside or outside of a PAK file for the TI-NPSIRE. 

This may cause a slight loading delay on other platforms in the case that a requested file cannot be found since we attempt to load it twice. However, this should not have meaningful user impact. 

### Visual Sample
Console prior to fix:
![image1](https://github.com/user-attachments/assets/fa87cf34-ca7c-481a-a73c-6a814766a65e)

Console after fix: 
![image0](https://github.com/user-attachments/assets/d374b84d-2080-4143-bd28-82c19c9d3a2b)


### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
