### PR TITLE
CTR: Fix crashes with sound name overflow

### DIFF
--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -441,7 +441,6 @@ void CL_ParseServerInfo (void)
 		CL_KeepaliveMessage ();
 		loading_cur_step++;
 		//Con_Printf("%i,",i);
-		strcpy(loading_name, sound_precache[i]);
 		SCR_UpdateScreen ();
 	}
 	S_EndPrecaching ();


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes a crash that could occur on CTR with levels that have a lot of sounds, this stemmed from a legacy feature where the loading screen would print the sound currently being precached, stored into a buffer and updated with `strcpy`. Because it is legacy I just removed this line.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
