### PR TITLE
PSP2: Fixes for unified texture loading branch

### DIFF
--- a/source/cl_hud.c
+++ b/source/cl_hud.c
@@ -210,6 +210,19 @@ void HUD_Init (void)
 	b_start = Image_LoadImage ("gfx/butticons/start", IMAGE_PNG, 0, true, false);
 	b_select = Image_LoadImage ("gfx/butticons/select", IMAGE_PNG, 0, true, false);
 	b_home = Image_LoadImage ("gfx/butticons/home", IMAGE_PNG, 0, true, false);
+#elif __vita__
+	b_circle = Image_LoadImage ("gfx/butticons/fbtncircle", IMAGE_TGA, 0, true, false);
+	b_square = Image_LoadImage ("gfx/butticons/fbtnsquare", IMAGE_TGA, 0, true, false);
+	b_cross = Image_LoadImage ("gfx/butticons/fbtncross", IMAGE_TGA, 0, true, false);
+	b_triangle = Image_LoadImage ("gfx/butticons/fbtntriangle", IMAGE_TGA, 0, true, false);
+	b_left = Image_LoadImage ("gfx/butticons/dpadleft", IMAGE_TGA, 0, true, false);
+	b_right = Image_LoadImage ("gfx/butticons/dpadright", IMAGE_TGA, 0, true, false);
+	b_up = Image_LoadImage ("gfx/butticons/dpadup", IMAGE_TGA, 0, true, false);
+	b_down = Image_LoadImage ("gfx/butticons/dpaddown", IMAGE_TGA, 0, true, false);
+	b_lt = Image_LoadImage ("gfx/butticons/backl1", IMAGE_TGA, 0, true, false);
+	b_rt = Image_LoadImage ("gfx/butticons/backr1", IMAGE_TGA, 0, true, false);
+	b_start = Image_LoadImage ("gfx/butticons/funcstart", IMAGE_TGA, 0, true, false);
+	b_select = Image_LoadImage ("gfx/butticons/funcselect", IMAGE_TGA, 0, true, false);
 #elif __3DS__
 	b_abutton = Image_LoadImage ("gfx/butticons/facebt_a", IMAGE_TGA, 0, true, false);
 	b_bbutton = Image_LoadImage ("gfx/butticons/facebt_b", IMAGE_TGA, 0, true, false);
@@ -239,7 +252,7 @@ void HUD_Init (void)
 	b_home = Image_LoadImage ("gfx/butticons/homebutton", IMAGE_TGA, 0, true, false);
 	b_one = Image_LoadImage ("gfx/butticons/1button", IMAGE_TGA, 0, true, false);
 	b_two = Image_LoadImage ("gfx/butticons/2button", IMAGE_TGA, 0, true, false);
-#endif // __PSP__, __3DS__, __WII__
+#endif // __PSP__, __vita__, __3DS__, __WII__
 
     fx_blood_lu = Image_LoadImage ("gfx/hud/blood", IMAGE_TGA, 0, true, false);
 

--- a/source/images.c
+++ b/source/images.c
@@ -236,6 +236,8 @@ int Image_LoadImage(char* filename, int image_format, int filter, qboolean keep,
 	
 #ifdef __PSP__
 	texture_index = GL_LoadImages (texname, image_width, image_height, data, true, filter, 0, 4, keep);
+#elif __vita__
+    texture_index = GL_LoadTexture32 (texname, image_width, image_height, data, false, true, false);
 #elif __3DS__
     texture_index = GL_LoadTexture (texname, image_width, image_height, data, mipmap, true, 4, keep);
 #elif __WII__

--- a/source/platform/psp2/vgl/vgl_draw.cpp
+++ b/source/platform/psp2/vgl/vgl_draw.cpp
@@ -953,23 +953,14 @@ void Draw_ColoredStretchPic (int x, int y, int pic, int x_value, int y_value, in
 {
 	glEnable(GL_BLEND);
 	glDisable(GL_ALPHA_TEST);
-	glColor4f(r/255.0,g/255.0,b/255.0,a/255.0);
+	Platform_Graphics_Color(r/255.0,g/255.0,b/255.0,a/255.0);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+	GL_EnableState(GL_MODULATE);
 
 	GL_Bind (pic);
-	glBegin (GL_QUADS);
-	glTexCoord2f (0, 0);
-	glVertex2f (x, y);
-	glTexCoord2f (1, 0);
-	glVertex2f (x+x_value, y);
-	glTexCoord2f (1, 1);
-	glVertex2f (x+x_value, y+y_value);
-	glTexCoord2f (0, 1);
-	glVertex2f (x, y+y_value);
-	glEnd ();
+	DrawQuad(x, y, x_value, y_value, 0, 0, 1, 1);
 
-	glColor4f(1,1,1,1);
+	Platform_Graphics_Color(1,1,1,1);
 }
 
 /*
@@ -980,21 +971,12 @@ Draw_StretchPic
 void Draw_StretchPic (int x, int y, int pic, int x_value, int y_value)
 {
 	glEnable(GL_ALPHA_TEST);
-	glColor4f(1,1,1,1);
+	Platform_Graphics_Color(1,1,1,1);
 
 	GL_Bind (pic);
-	glBegin (GL_QUADS);
-	glTexCoord2f (0, 0);
-	glVertex2f (x, y);
-	glTexCoord2f (1, 0);
-	glVertex2f (x+x_value, y);
-	glTexCoord2f (1, 1);
-	glVertex2f (x+x_value, y+y_value);
-	glTexCoord2f (0, 1);
-	glVertex2f (x, y+y_value);
-	glEnd ();
+	DrawQuad(x, y, x_value, y_value, 0, 0, 1, 1);
 
-	glColor4f(1,1,1,1);
+	Platform_Graphics_Color(1,1,1,1);
 }
 
 /*
@@ -1006,25 +988,16 @@ void Draw_ColorPic (int x, int y, int pic, float r, float g , float b, float a)
 {
 	glDisable(GL_ALPHA_TEST);
 	glEnable(GL_BLEND);
-	glColor4f(r/255.0f,g/255.0f,b/255.0f,a/255.0f);
+	Platform_Graphics_Color(r/255.0f,g/255.0f,b/255.0f,a/255.0f);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+	GL_EnableState(GL_MODULATE);
 	GL_Bind (pic);
 
-	glBegin (GL_QUADS);
-	glTexCoord2f (0, 0);
-	glVertex2f (x, y);
-	glTexCoord2f (1, 0);
-	glVertex2f (x+gltextures[pic].width, y);
-	glTexCoord2f (1, 1);
-	glVertex2f (x+gltextures[pic].width, y+gltextures[pic].height);
-	glTexCoord2f (0, 1);
-	glVertex2f (x, y+gltextures[pic].height);
-	glEnd ();
+	DrawQuad(x, y, gltextures[pic].width, gltextures[pic].height, 0, 0, 1, 1);
 
 	glDisable(GL_BLEND);
 	//glDisable(GL_ALPHA_TEST);
-	glColor4f(1,1,1,1);
+	Platform_Graphics_Color(1,1,1,1);
 }
 
 /*


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixed Draw_ColoredStretchPic, Draw_StretchPic and Draw_ColorPic using Immediate Mode
Fixed Image_LoadImage not having code to load the images on Vita, making the game crash
Fixed HUD_Init no longer loading vita button prompts
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1fb33549-faaf-440f-84eb-fc7b51790bed" />

### Checklist
---

- [X] I have thoroughly tested my changes to the best of my ability
- [X] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
