### PR TITLE
Fix view model skin from being incorrect while drinking perks

### DIFF
--- a/source/platform/psp/gu/gu_model.cpp
+++ b/source/platform/psp/gu/gu_model.cpp
@@ -1973,15 +1973,6 @@ qboolean model_is_zombie(char name[MAX_QPATH])
 Mod_LoadAllSkins
 ===============
 */
-extern int has_pap;
-extern int has_perk_revive;
-extern int has_perk_juggernog;
-extern int has_perk_speedcola;
-extern int has_perk_doubletap;
-extern int has_perk_staminup;
-extern int has_perk_flopper;
-extern int has_perk_deadshot;
-extern int has_perk_mulekick;
 void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 {
 	int 	i = 0;
@@ -2053,118 +2044,6 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 			return (void *)pskintype;
 		}
-
-		// Perk Bottles // v_perk
-		if (strcmp(loadmodel->name, "models/machines/v_perk.mdl") == 0) {
-			for (int i = 0; i < 8; i++) {
-				if (i == 0 && has_perk_revive) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_0", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_revive && i == 0) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 1 && has_perk_juggernog) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_1", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_juggernog && i == 1) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 2 && has_perk_speedcola) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_2", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_speedcola && i == 2) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 3 && has_perk_doubletap) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_3", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_doubletap && i == 3) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 4 && has_perk_staminup) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_4", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_staminup && i == 4) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 5 && has_perk_flopper) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_5", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_flopper && i == 5) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 6 && has_perk_deadshot) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_6", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_deadshot && i == 6) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-				if (i == 7 && has_perk_mulekick) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadpcxas4bpp("models/machines/v_perk.mdl_7", GU_LINEAR);
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				} else if (!has_perk_mulekick && i == 7) {
-					pheader->gl_texturenum[i][0] =
-					pheader->gl_texturenum[i][1] =
-					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
-					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-				}
-			}
-
-			return (void *)pskintype;
-		}
 	}
 
 	qboolean is_gun = model_is_gun(loadmodel->name);
@@ -2172,23 +2051,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 
 	for (i=0 ; i<numskins ; i++)
 	{
-		if (!has_pap && is_gun && i >= 1) {
-			pheader->gl_texturenum[i][0] = 
-			pheader->gl_texturenum[i][1] = 
-			pheader->gl_texturenum[i][2] = 
-			pheader->gl_texturenum[i][3] = pheader->gl_texturenum[0][0];
-			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-			return (void *)pskintype;
-		}
-		else if (has_pap && is_gun && i >= 1 && psp_system_model == PSP_MODEL_PHAT) {
-			pheader->gl_texturenum[i][0] = 
-			pheader->gl_texturenum[i][1] = 
-			pheader->gl_texturenum[i][2] = 
-			pheader->gl_texturenum[i][3] = loadtextureimage("models/weapons/v_papskin", 0, 0, qtrue, GU_LINEAR);
-			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-			return (void *)pskintype;
-		}
-		else if (pskintype->type == ALIAS_SKIN_SINGLE)
+		if (pskintype->type == ALIAS_SKIN_SINGLE)
 		{
 			Mod_FloodFillSkin( skin, pheader->skinwidth, pheader->skinheight );
 			COM_StripExtension(loadmodel->name, model);

--- a/source/platform/psp/gu/gu_model.cpp
+++ b/source/platform/psp/gu/gu_model.cpp
@@ -1927,22 +1927,6 @@ void Mod_FloodFillSkin( byte *skin, int skinwidth, int skinheight )
 	}
 }
 
-qboolean model_is_gun(char name[MAX_QPATH])
-{
-	char wep_path[15];
-
-	for (int i = 0; i < 15; i++) {
-		wep_path[i] = name[i];
-	}
-	wep_path[14] = '\0';
-
-	if (strcmp(wep_path, "models/weapons") == 0) {
-		return qtrue;
-	}
-
-	return qfalse;
-}
-
 qboolean model_is_viewmodel(char * name)
 {
 	if (strstr(name, "/v_") != NULL) {
@@ -2046,7 +2030,6 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 		}
 	}
 
-	qboolean is_gun = model_is_gun(loadmodel->name);
 	qboolean is_viewmodel = model_is_viewmodel(loadmodel->name);
 
 	for (i=0 ; i<numskins ; i++)


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Depreciated old and broken function for loading perk skins in Mod_LoadAllSkins

### Visual Sample

https://github.com/user-attachments/assets/2e5074ae-abf7-4804-a57e-4d0d349f2fdb




### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
