### PR TITLE
GLOBAL: Send bind release on let go of dtkey

### DIFF
--- a/source/keys.c
+++ b/source/keys.c
@@ -973,7 +973,8 @@ void Key_Event (int key, qboolean down)
 		if (dtfired[key]) {
 			kb = dtbindings[key];
 			if (kb && kb[0] == '+') {
-				sprintf (cmd, "-%s %i\n", kb + 1, key);
+				sprintf (cmd, "-%.*s %i\n",
+					(int)strcspn(kb + 1, " ;\t\r\n"), kb + 1, key);
 				Cbuf_AddText (cmd);
 			}
 			dtfired[key] = false;
@@ -1008,7 +1009,8 @@ void Key_Event (int key, qboolean down)
 			{
 				if (kb[0] == '+')
 				{	// button commands add keynum as a parm
-					Key_RunBinding (kb, key);
+					sprintf (cmd, kb, key);
+					Cbuf_AddText (cmd);
 					dtfired[key] = true;
 				}
 				else

--- a/source/keys.c
+++ b/source/keys.c
@@ -48,6 +48,7 @@ qboolean	keydown[256];
 static double holdstart[256];
 static qboolean holdfired[256];
 static qboolean defernormal[256];
+static qboolean dtfired[256];
 
 #define HOLD_BIND_TIME 0.2
 
@@ -969,6 +970,14 @@ void Key_Event (int key, qboolean down)
 // downs can be matched with ups
 //
 	if (!down) {
+		if (dtfired[key]) {
+			kb = dtbindings[key];
+			if (kb && kb[0] == '+') {
+				sprintf (cmd, "-%s %i\n", kb + 1, key);
+				Cbuf_AddText (cmd);
+			}
+			dtfired[key] = false;
+		}
 		kb = keybindings[key];
 		if (!defernormal[key] && kb && kb[0] == '+') {
 			sprintf (cmd, "-%s %i\n", kb+1, key);
@@ -999,8 +1008,8 @@ void Key_Event (int key, qboolean down)
 			{
 				if (kb[0] == '+')
 				{	// button commands add keynum as a parm
-					sprintf (cmd, kb, key);
-					Cbuf_AddText (cmd);
+					Key_RunBinding (kb, key);
+					dtfired[key] = true;
 				}
 				else
 				{
@@ -1073,5 +1082,6 @@ void Key_ClearStates (void)
 		holdstart[i] = 0;
 		holdfired[i] = false;
 		defernormal[i] = false;
+		dtfired[i] = false;
 	}
 }


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Explicitly sends release of commands for double-tapped binds instead of trusting single release to do the job. Fixes https://github.com/nzp-team/nzportable/issues/1512, fixes https://github.com/nzp-team/nzportable/issues/1384
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
