### PR TITLE
SERVER: Mask the sign bit for OR and AND QC operations

### DIFF
--- a/source/pr_exec.c
+++ b/source/pr_exec.c
@@ -46,6 +46,11 @@ int			pr_xstatement;
 
 int		pr_argc;
 
+static qboolean PR_IsTruthy (const eval_t *value)
+{
+	return ((unsigned int)value->_int & 0x7fffffffU) != 0;
+}
+
 char *pr_opnames[] =
 {
 "DONE",
@@ -473,10 +478,10 @@ while (1)
 		c->_float = a->_float < b->_float;
 		break;
 	case OP_AND:
-		c->_float = a->_float && b->_float;
+		c->_float = PR_IsTruthy(a) && PR_IsTruthy(b);
 		break;
 	case OP_OR:
-		c->_float = a->_float || b->_float;
+		c->_float = PR_IsTruthy(a) || PR_IsTruthy(b);
 		break;
 
 	case OP_NOT_F:


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
When compiling some targets with `-ffast-math` `0.0` won't equal `-0.0`. This can cause logic errors in the QCVM leading to skipped or incorrectly executed logic on the server posing significant gameplay issues. Fixes https://github.com/nzp-team/nzportable/issues/1490
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
