### PR TITLE
PSP: re-enable AdHoc multiplayer (COOPERATIVE menu) + fix the netcode that broke it

### DIFF
--- a/Makefile.psp
+++ b/Makefile.psp
@@ -81,6 +81,7 @@ COMMON_OBJS = \
 	source/menu/menu_loadscreen.o \
 	source/menu/menu_bios.o \
 	source/menu/menu_credits.o \
+	source/menu/menu_coop.o \
 	source/platform/psp/net_dgrm.o \
 	source/net_loop.o \
 	source/platform/psp/net_main.o \

--- a/source/cl_hud.c
+++ b/source/cl_hud.c
@@ -530,6 +530,18 @@ void HUD_Points (void)
 
 	// draw background
 
+	// the counter animation state (old_points/current_points) is a
+	// single global set, so only animate the local player's row —
+	// other players' rows draw their raw score
+		if (k != cl.viewentity - 1)
+		{
+			Draw_StretchPic (x, y, sb_moneyback, 64 * vid.scale, 16 * vid.scale);
+			xplus = getTextWidth(va("%i", s->points), vid.scale);
+			Draw_ColoredString((((64 * vid.scale) - xplus)/2) + (5 * vid.scale), y + (3 * vid.scale), va("%i", s->points), 255, 255, 255, 255, vid.scale);
+			y += 10;
+			continue;
+		}
+
 	// draw number
 		f = s->points;
 		if (f > current_points)
@@ -779,11 +791,11 @@ void HUD_MaxAmmo(void)
 	double start_time, end_time;
 
 	// For the first 0.5s, stay still while we fade in
-	if (hud_maxammo_endtime > sv.time + 1.5) {
+	if (hud_maxammo_endtime > cl.time + 1.5) {
 		start_time = hud_maxammo_starttime;
 		end_time = hud_maxammo_starttime + 0.5;
 
-		text_alpha = (sv.time - start_time) / (end_time - start_time);
+		text_alpha = (cl.time - start_time) / (end_time - start_time);
 		pos_y = start_y;
 	}
 	// For the remaining 1.5s, fade out while we fly upwards.
@@ -791,7 +803,7 @@ void HUD_MaxAmmo(void)
 		start_time = hud_maxammo_starttime + 0.5;
 		end_time = hud_maxammo_endtime;
 
-		float percent_time = (sv.time - start_time) / (end_time - start_time);
+		float percent_time = (cl.time - start_time) / (end_time - start_time);
 
 		pos_y = start_y + diff_y * percent_time;
 		text_alpha = 1 - percent_time;
@@ -1523,7 +1535,7 @@ void HUD_ProgressBar (void)
 
 	if (cl.progress_bar)
 	{
-		progressbar = 100 - ((cl.progress_bar-sv.time)*10);
+		progressbar = 100 - ((cl.progress_bar-cl.time)*10);
 		if (progressbar >= 100)
 			progressbar = 100;
 		Draw_FillByColor  ((vid.width)/2 - 51, vid.height*0.75 - 1, 102, 5, 0, 0, 0,100);
@@ -1724,7 +1736,13 @@ void HUD_Weapon (void)
 	x_value = vid.width;
 	y_value = vid.height - (40 * vid.scale);
 
-	strcpy(str, PR_GetString(sv_player->v.Weapon_Name));
+	// replicated from the server via svc_weapondata — valid on the
+	// listen host and on remote clients alike
+	extern char cl_weaponname[64];
+	if (!cl_weaponname[0])
+		return;
+
+	strcpy(str, cl_weaponname);
 
 	x_value = (vid.width - (55 * vid.scale)) - getTextWidth(str, vid.scale);
 	Draw_ColoredString (x_value, y_value, str, 255, 255, 255, 255, vid.scale);
@@ -1794,8 +1812,8 @@ void HUD_PlayerName (void)
 {
 	int alpha = 255;
 
-	if (nameprint_time - sv.time < 1)
-		alpha = (int)((nameprint_time - sv.time)*255);
+	if (nameprint_time - cl.time < 1)
+		alpha = (int)((nameprint_time - cl.time)*255);
 
 	Draw_ColoredString(70 * vid.scale, vid.height - (70 * vid.scale), player_name, 255, 255, 255, alpha, vid.scale);
 }
@@ -1868,12 +1886,12 @@ HUD_GunGame
 */
 void HUD_GunGame (void)
 {
-	char weapon_id[64];
+	char weapon_id[96];
 	char point_info[64];
 
 	int client_points = 0;
 
-	for(int i = 0; i < svs.maxclients; i++) {
+	for(int i = 0; i < cl.maxclients; i++) {
 		if (i == cl.viewentity - 1) {
 			client_points = cl.scores[i].points;
 			break;
@@ -1886,7 +1904,11 @@ void HUD_GunGame (void)
 		sprintf(weapon_id, "You've passed all weapons!");
 		sprintf(point_info, "The Winner can choose to End the Game");
 	} else {
-		sprintf(weapon_id, "%s [%d/32]", PR_GetString(sv_player->v.Weapon_Name), cl.stats[STAT_GUNGAME_IDX] + 1);
+		// weapon name replicated via svc_weapondata
+		{
+			extern char cl_weaponname[64];
+			snprintf(weapon_id, sizeof(weapon_id), "%.48s [%d/32]", cl_weaponname, cl.stats[STAT_GUNGAME_IDX] + 1);
+		}
 		sprintf(point_info, "[%d] Score until next Weapon", cl.stats[STAT_GUNGAME_SCOREGOAL] - client_points);
 	}
 
@@ -1907,7 +1929,7 @@ void HUD_Draw (void)
 
 	if (key_dest == key_menu_pause) {
 		// Make sure we still draw the screen flash.
-		if (screenflash_duration > sv.time)
+		if (screenflash_duration > cl.time)
 			HUD_Screenflash();
 		return;
 	}
@@ -1932,7 +1954,7 @@ void HUD_Draw (void)
 		HUD_EndScreen ();
 		
 		// Make sure we still draw the screen flash.
-		if (screenflash_duration > sv.time)
+		if (screenflash_duration > cl.time)
 			HUD_Screenflash();
 
 		return;
@@ -1944,16 +1966,16 @@ void HUD_Draw (void)
 		HUD_Points();
 		HUD_Point_Change();
 
-		if (screenflash_duration > sv.time)
+		if (screenflash_duration > cl.time)
 			HUD_Screenflash();
 		
 		return;
 	}
 
-	if (bettyprompt_time > sv.time)
+	if (bettyprompt_time > cl.time)
 		HUD_BettyPrompt();
 
-	if (nameprint_time > sv.time)
+	if (nameprint_time > cl.time)
 		HUD_PlayerName();
 
 	HUD_Blood();
@@ -1974,7 +1996,7 @@ void HUD_Draw (void)
 	HUD_Point_Change();
 	HUD_Achievement();
 
-	if (hud_maxammo_endtime > sv.time)
+	if (hud_maxammo_endtime > cl.time)
 		HUD_MaxAmmo();
 
 	switch(current_gamemode) {
@@ -1983,6 +2005,6 @@ void HUD_Draw (void)
 	}
 
 	// This should always come last!
-	if (screenflash_duration > sv.time)
+	if (screenflash_duration > cl.time)
 		HUD_Screenflash();
 }

--- a/source/cl_input.c
+++ b/source/cl_input.c
@@ -318,7 +318,10 @@ void CL_AdjustAngles (void)
 	// ==== Aim Assist + ====
 	// cut look speed in half when facing enemy, unless
 	// mag is empty
-	if ((in_aimassist.value) && (sv_player->v.facingenemy == 1) && cl.stats[STAT_CURRENTMAG] > 0) {
+	// (replicated via STAT_FACINGENEMY — correct for the local player
+	// on both host and remote clients; sv_player is NOT: on a listen
+	// host with >1 client it points at the last client processed)
+	if ((in_aimassist.value) && (cl.stats[STAT_FACINGENEMY] == 1) && cl.stats[STAT_CURRENTMAG] > 0) {
 		speed *= 0.5f;
 	}
 	// additionally, slice look speed when ADS/scopes
@@ -386,7 +389,10 @@ void CL_BaseMove (usercmd_t *cmd)
 	Q_memset (cmd, 0, sizeof(*cmd));
 
 	// cypress - we handle movespeed in QC now.
-	cl_backspeed = cl_forwardspeed = cl_sidespeed = sv_player->v.maxspeed;
+	// (replicated via STAT_MAXSPEED — correct for the local player on
+	// both host and remote clients, unlike sv_player which tracks the
+	// last client the server processed)
+	cl_backspeed = cl_forwardspeed = cl_sidespeed = (cl.stats[STAT_MAXSPEED] > 0) ? cl.stats[STAT_MAXSPEED] : 190;
 
 	// Throttle side and back speeds
 	cl_sidespeed *= 0.8f;
@@ -491,6 +497,10 @@ void CL_Aim_Snap(void)
 	float bestDist = 10000;
 	vec3_t distVec, zOrg, pOrg;
 	//32 is v_ofs num
+
+	// walks server edicts — only possible on the listen host
+	if (!sv.active)
+		return;
 
 	bz = sv.edicts;
 

--- a/source/cl_main.c
+++ b/source/cl_main.c
@@ -680,9 +680,15 @@ void CL_RelinkEntities (void)
 				smokeorg[2] += cl.viewheight; // account for beta maps
 				VectorCopy(smokeorg,start);
 
-				right_offset	 = sv_player->v.Flash_Offset[0];
-				up_offset		 = sv_player->v.Flash_Offset[1];
-				forward_offset 	 = sv_player->v.Flash_Offset[2];
+				// per-weapon flash offset replicated via
+				// svc_weapondata — valid on the listen host and on
+				// remote clients alike
+				{
+					extern float cl_flash_offset[3];
+					right_offset	 = cl_flash_offset[0];
+					up_offset		 = cl_flash_offset[1];
+					forward_offset 	 = cl_flash_offset[2];
+				}
 				 
 				right_offset	= right_offset/1000;
 				up_offset		= up_offset/1000;

--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -30,6 +30,13 @@ extern cvar_t cl_hitmarkers;
 
 qboolean 			crosshair_pulse_grenade;
 
+// per-weapon client visuals replicated from the server via
+// svc_weapondata — remote clients cannot read the host's progs
+char				cl_weaponname[64];
+float				cl_ads_offset[3];
+float				cl_flash_offset[3];
+float				cl_flash_size;
+
 extern int EN_Find(int num,char *string);
 
 char *svc_strings[] =
@@ -199,7 +206,11 @@ void CL_KeepaliveMessage (void)
 	static double lastmsg;//BLUBSFIX, this was a float
 	int		ret;
 	sizebuf_t	old;
-	byte		olddata[8192];
+	// MUST hold a full reliable message — net_message.cursize goes up
+	// to NET_MAXMESSAGE (16384). The old 8192 here smashed the stack
+	// (return address overwritten with precache strings) whenever the
+	// serverinfo message of a remote server exceeded 8KB.
+	byte		olddata[NET_MAXMESSAGE];
 
 	if (sv.active)
 	{
@@ -309,6 +320,11 @@ void CL_ParseServerInfo (void)
 //
 	CL_ClearState ();
 
+	cl_weaponname[0] = 0;
+	memset (cl_ads_offset, 0, sizeof(cl_ads_offset));
+	memset (cl_flash_offset, 0, sizeof(cl_flash_offset));
+	cl_flash_size = 0;
+
 // parse protocol version number
 	i = MSG_ReadLong ();
 	if (i != PROTOCOL_VERSION)
@@ -374,6 +390,9 @@ void CL_ParseServerInfo (void)
 			return;
 		}
 
+		if (msg_badread)
+			Host_Error ("CL_ParseServerInfo: bad model precache list");
+
 		Q_strncpyz (model_precache[nummodels], str, sizeof(model_precache[nummodels]));
 		//Con_Printf("%i,",nummodels);
 
@@ -401,7 +420,11 @@ void CL_ParseServerInfo (void)
 			Con_Printf ("Server sent too many sound precaches\n");
 			return;
 		}
-		strcpy (sound_precache[numsounds], str);
+		if (msg_badread)
+			Host_Error ("CL_ParseServerInfo: bad sound precache list");
+		// str can exceed MAX_QPATH on a corrupt/misaligned message —
+		// never let it smash the stack
+		Q_strncpyz (sound_precache[numsounds], str, sizeof(sound_precache[numsounds]));
 		S_TouchSound (str);
 		//Con_Printf("%i,",numsounds);
 	}
@@ -421,8 +444,7 @@ void CL_ParseServerInfo (void)
 	//Con_Printf("Loaded Model: ");
 
 	for (i=1 ; i<nummodels ; i++)
-	{
-		cl.model_precache[i] = Mod_ForName (model_precache[i], false);
+	{		cl.model_precache[i] = Mod_ForName (model_precache[i], false);
 
 		// rbaldwin2 -- At last resort use a missing model
 		if (cl.model_precache[i] == NULL)
@@ -458,8 +480,7 @@ void CL_ParseServerInfo (void)
 	S_BeginPrecaching ();
 	//Con_Printf("Loaded Sounds: ");
 	for (i=1 ; i<numsounds ; i++)
-	{
-		cl.sound_precache[i] = S_PrecacheSound (sound_precache[i]);
+	{		cl.sound_precache[i] = S_PrecacheSound (sound_precache[i]);
 		CL_KeepaliveMessage ();
 		loading_cur_step++;
 		LoadingScreen_AdvanceProgress();
@@ -1045,6 +1066,14 @@ void CL_ParseClientdata (int bits)
 	i = MSG_ReadShort ();
 	if (cl.stats[STAT_GUNGAME_SCOREGOAL] != i)
 		cl.stats[STAT_GUNGAME_SCOREGOAL] = i;
+
+	i = MSG_ReadShort ();
+	if (cl.stats[STAT_MAXSPEED] != i)
+		cl.stats[STAT_MAXSPEED] = i;
+
+	i = MSG_ReadByte ();
+	if (cl.stats[STAT_FACINGENEMY] != i)
+		cl.stats[STAT_FACINGENEMY] = i;
 }
 
 /*
@@ -1107,7 +1136,7 @@ void CL_ParseWeaponFire (void)
 {
 	vec3_t		kick;
 	return_time = (double)6/MSG_ReadLong ();
-	crosshair_spread_time = return_time + sv.time;
+	crosshair_spread_time = return_time + cl.time;
 
 	kick[0] = MSG_ReadCoord()/5;
 	kick[1] = MSG_ReadCoord()/5;
@@ -1235,11 +1264,28 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_useprint:
-			SCR_UsePrint (MSG_ReadByte (),MSG_ReadShort (),MSG_ReadByte ());
+		{
+			int up_type   = MSG_ReadByte ();
+			int up_cost   = MSG_ReadShort ();
+			int up_weapon = MSG_ReadByte ();
+			SCR_UsePrint (up_type, up_cost, up_weapon, MSG_ReadString ());
 			break;
+		}
+
+		case svc_weapondata:
+		{
+			int k;
+			Q_strncpyz (cl_weaponname, MSG_ReadString (), sizeof(cl_weaponname));
+			for (k = 0; k < 3; k++)
+				cl_ads_offset[k] = MSG_ReadShort ();
+			for (k = 0; k < 3; k++)
+				cl_flash_offset[k] = MSG_ReadShort ();
+			cl_flash_size = MSG_ReadShort ();
+			break;
+		}
 		case svc_maxammo:
-			hud_maxammo_starttime = sv.time;
-			hud_maxammo_endtime = sv.time + 2;
+			hud_maxammo_starttime = cl.time;
+			hud_maxammo_endtime = cl.time + 2;
 			break;
 
 		case svc_pulse:
@@ -1277,21 +1323,21 @@ void CL_ParseServerMessage (void)
 
 		case svc_screenflash:
 			screenflash_color = MSG_ReadByte();
-			screenflash_duration = sv.time + MSG_ReadByte();
+			screenflash_duration = cl.time + MSG_ReadByte();
 			screenflash_type = MSG_ReadByte();
 			screenflash_worktime = 0;
-			screenflash_starttime = sv.time;
+			screenflash_starttime = cl.time;
 
 			if (screenflash_color == SCREENFLASH_COLOR_WHITE && scr_whiteflash.value == 1)
 				screenflash_color = SCREENFLASH_COLOR_BLACK;
 			break;
 
 		case svc_bettyprompt:
-			bettyprompt_time = sv.time + 4;
+			bettyprompt_time = cl.time + 4;
 			break;
 
 		case svc_playername:
-			nameprint_time = sv.time + 11;
+			nameprint_time = cl.time + 11;
 			strcpy(player_name, MSG_ReadString());
 			break;
 
@@ -1444,7 +1490,7 @@ void CL_ParseServerMessage (void)
 
 		case svc_hitmark:
 			if (cl_hitmarkers.value > 0)
-				Hitmark_Time = sv.time + 0.2;
+				Hitmark_Time = cl.time + 0.2;
 			break;
 
 		case svc_weaponfire:

--- a/source/host.c
+++ b/source/host.c
@@ -98,10 +98,17 @@ qboolean bmg_type_changed = false;
 Host_EndGame
 ================
 */
+void Menu_ExitMap (void);
+
+// set when a remote client loses its server; consumed at the top of
+// _Host_Frame where running the menu-return sequence is safe
+static qboolean host_return_to_menu = false;
+
 void Host_EndGame (char *message, ...)
 {
 	va_list		argptr;
 	char		string[1024];
+	qboolean	was_remote_client = (!sv.active && cls.state == ca_connected && !cls.demoplayback);
 
 	va_start (argptr,message);
 	vsprintf (string,message,argptr);
@@ -118,6 +125,13 @@ void Host_EndGame (char *message, ...)
 		CL_NextDemo ();
 	else
 		CL_Disconnect ();
+
+	// a remote client has no local server to fall back to — return to
+	// the main menu instead of leaving a dead scene with no input focus
+	// (deferred to the next _Host_Frame: this error path may run inside
+	// rendering, where unloading textures is unsafe)
+	if (was_remote_client)
+		host_return_to_menu = true;
 
     Clear_LoadingFill ();
 
@@ -136,6 +150,7 @@ void Host_Error (char *error, ...)
 	va_list		argptr;
 	char		string[1024];
 	static	qboolean inerror = false;
+	qboolean	was_remote_client = (!sv.active && cls.state == ca_connected && !cls.demoplayback);
 
 	if (inerror)
 		Sys_Error ("Host_Error: recursively entered");
@@ -156,6 +171,10 @@ void Host_Error (char *error, ...)
 
 	CL_Disconnect ();
 	cls.demonum = -1;
+
+	// see Host_EndGame — don't strand a remote client on a dead scene
+	if (was_remote_client)
+		host_return_to_menu = true;
 
 	Clear_LoadingFill ();
 
@@ -629,7 +648,15 @@ void _Host_Frame (float time)
 	{
 		return;			// something bad happened, or the server disconnected
 	}
-	
+
+// a remote client lost its server last frame (Host_EndGame/Host_Error) —
+// recover to the main menu now, at a safe point outside the error path
+	if (host_return_to_menu)
+	{
+		host_return_to_menu = false;
+		Menu_ExitMap ();
+	}
+
 // keep the random time dependent
 	rand ();
 

--- a/source/input.c
+++ b/source/input.c
@@ -103,7 +103,10 @@ void IN_Move(usercmd_t *cmd)
 	}
 
 	speed = sensitivity.value;
-	if (in_aimassist.value && sv_player->v.facingenemy == 1 && cl.stats[STAT_CURRENTMAG] > 0)
+	// replicated via STAT_FACINGENEMY — correct for the local player on
+	// both host and remote clients (sv_player is not: it tracks the last
+	// client the server processed)
+	if (in_aimassist.value && (cl.stats[STAT_FACINGENEMY] == 1) && cl.stats[STAT_CURRENTMAG] > 0)
 		speed *= 0.5f;
 	if (cl.stats[STAT_ZOOM] == 1)
 		speed *= 0.5f;
@@ -118,7 +121,9 @@ void IN_Move(usercmd_t *cmd)
 		* look_y * (float)host_frametime;
 	cl.viewangles[PITCH] = IN_Clamp(cl.viewangles[PITCH], -70.0f, 80.0f);
 
-	cl_backspeed = cl_forwardspeed = cl_sidespeed = sv_player->v.maxspeed;
+	// replicated via STAT_MAXSPEED — correct for the local player on
+	// both host and remote clients
+	cl_backspeed = cl_forwardspeed = cl_sidespeed = (cl.stats[STAT_MAXSPEED] > 0) ? cl.stats[STAT_MAXSPEED] : 190;
 	cl_sidespeed *= 0.8f;
 	cl_backspeed *= 0.7f;
 	move_x = IN_ShapeAxis(move_stick.x, cl_sidespeed, tolerance, acceleration);

--- a/source/menu/menu.c
+++ b/source/menu/menu.c
@@ -37,6 +37,10 @@ void Menu_Audio_Draw (void);
 void Menu_Controls_Draw (void);
 void Menu_Bindings_Draw (void);
 void Menu_Accessibility_Draw (void);
+#ifdef __PSP__
+void Menu_Coop_Draw (void);
+void Menu_CoopJoin_Draw (void);
+#endif
 
 menu_t			current_menu;
 menu_button_t	current_menu_buttons[MAX_MENU_BUTTONS];
@@ -267,6 +271,16 @@ void Menu_Draw (void)
 		Menu_Bios_Draw ();
 		break;
 
+#ifdef __PSP__
+	case m_coop:
+		Menu_Coop_Draw ();
+		break;
+
+	case m_coopjoin:
+		Menu_CoopJoin_Draw ();
+		break;
+#endif
+
 	default:
 		Con_Printf("Cannot identify menu for case %d\n", m_state);
 	}
@@ -294,7 +308,12 @@ void Menu_ToggleMenu_f (void)
 	}
 	if (key_dest == key_console) {
 		Con_ToggleConsole_f ();
-	} else if (sv.active && (svs.maxclients > 1 || key_dest == key_game)) {
+	} else if ((sv.active && (svs.maxclients > 1 || key_dest == key_game)) ||
+	           (!sv.active && cls.state == ca_connected && !cls.demoplayback)) {
+		// second clause: we are a remote client on someone else's
+		// server — the pause menu (with its disconnect option) is the
+		// only sane in-game menu there (demo playback excluded: it
+		// also runs connected without a local server)
 		Menu_Pause_Set();
 	} else {
 		Menu_Main_Set ();

--- a/source/menu/menu_coop.c
+++ b/source/menu/menu_coop.c
@@ -1,0 +1,276 @@
+/*
+Copyright (C) 2025-2026 NZ:P Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+#include "../nzportable_def.h"
+#include "menu_defs.h"
+
+#ifdef __PSP__
+
+#include <pspkernel.h>
+#include <pspwlan.h>
+#include "../platform/psp/net_dgrm.h"
+
+// defined in platform/psp/net_dgrm.c — restores this menu when a
+// connect attempt fails
+extern int		m_return_state;
+extern qboolean	m_return_onerror;
+extern char		m_return_reason[32];
+
+//=============================================================================
+/* COOPERATIVE (ADHOC) MENU */
+
+static qboolean adhoc_failed;
+
+/*
+===============
+Menu_Coop_EnableAdhoc
+
+Bring up the AdHoc landriver, mirroring the v1 activation flow:
+Datagram_Shutdown -> tcpipAvailable/tcpipAdhoc -> net_driver_to_use=1 ->
+Datagram_Init. Returns true when the driver is (already) up.
+===============
+*/
+static qboolean adhoc_starting;
+
+static qboolean Menu_Coop_EnableAdhoc (void)
+{
+	if (net_landrivers[1].initialized)
+		return true;
+
+	// hardware WLAN switch must be on — adhocctl can otherwise
+	// stall for the full join timeout
+	if (!sceWlanDevIsPowerOn()) {
+		adhoc_failed = true;
+		Menu_SetSound(MENU_SND_BEEP);
+		return false;
+	}
+
+	// joining the adhocctl group blocks for up to ~10s — push one
+	// frame with the "STARTING ADHOC..." notice before stalling
+	adhoc_starting = true;
+	SCR_UpdateScreen();
+	adhoc_starting = false;
+
+	// two attempts: PPSSPP's built-in adhoc server starts alongside
+	// the first network init, so the very first join can race it and
+	// time out — the retry then lands on a warm server
+	for (int attempt = 0; attempt < 2 && !net_landrivers[1].initialized; attempt++) {
+		if (attempt > 0)
+			sceKernelDelayThread(1000 * 1000); // let adhocctl teardown settle
+
+		Datagram_Shutdown();
+
+		tcpipAvailable = true;
+		tcpipAdhoc = true;
+		net_driver_to_use = 1; // landriver 1 = AdHoc
+
+		Datagram_Init();
+	}
+
+	// Datagram_Init returns 0 even when the landriver failed, so
+	// check the flag instead
+	if (!net_landrivers[1].initialized) {
+		tcpipAvailable = false;
+		tcpipAdhoc = false;
+		net_driver_to_use = 0;
+		adhoc_failed = true;
+		Menu_SetSound(MENU_SND_BEEP);
+		return false;
+	}
+
+	adhoc_failed = false;
+	return true;
+}
+
+static void Menu_Coop_HostGame (void)
+{
+	if (!Menu_Coop_EnableAdhoc())
+		return;
+
+	menu_is_solo = false; // flips map selection into COOP mode
+	Menu_StockMaps_Set();
+}
+
+static void Menu_Coop_JoinGame (void)
+{
+	if (!Menu_Coop_EnableAdhoc())
+		return;
+
+	menu_is_solo = false;
+	Menu_CoopJoin_Set();
+}
+
+/*
+===============
+Menu_Coop_Set
+===============
+*/
+void Menu_Coop_Set (void)
+{
+	Menu_ResetMenuButtons();
+	Menu_SetSound(MENU_SND_ENTER);
+
+	adhoc_failed = false;
+
+	key_dest = key_menu;
+	m_previous_state = m_main;
+	m_state = m_coop;
+}
+
+/*
+===============
+Menu_Coop_Draw
+===============
+*/
+void Menu_Coop_Draw (void)
+{
+	// Background
+	Menu_DrawCustomBackground (true);
+
+	// Header
+	Menu_DrawTitle ("COOPERATIVE", MENU_COLOR_WHITE);
+
+	// Version String
+	Menu_DrawBuildDate();
+
+	Menu_DrawButton(1, 0, "HOST GAME", "Create an AdHoc Game for nearby PSPs.", Menu_Coop_HostGame);
+	Menu_DrawButton(2, 1, "JOIN GAME", "Search for AdHoc Games near you.", Menu_Coop_JoinGame);
+
+	Menu_DrawButton(-1, 2, "BACK", "Return to Main Menu.", Menu_Main_Set);
+
+	if (adhoc_starting) {
+		Menu_DrawGreyButton(4, "STARTING ADHOC...");
+	} else if (adhoc_failed) {
+		if (!sceWlanDevIsPowerOn())
+			Menu_DrawGreyButton(4, "TURN ON THE WLAN SWITCH!");
+		else
+			Menu_DrawGreyButton(4, "COULD NOT START ADHOC.");
+	}
+}
+
+//=============================================================================
+/* JOIN GAME (host browser over the slist host cache) */
+
+static int		join_last_count = -1;
+static qboolean	join_last_scanning;
+static char		join_rows[HOSTCACHESIZE][48];
+
+static void Menu_CoopJoin_StartScan (void)
+{
+	if (slistInProgress)
+		return;
+
+	m_return_reason[0] = 0;
+	hostCacheCount = 0;
+	slistSilent = true; // no console spam
+	slistLocal = false; // skip the loopback driver
+	NET_Slist_f(); // NET_Poll (host.c) drives the scan every frame
+}
+
+static void Menu_CoopJoin_Connect (void)
+{
+	int idx = current_menu.cursor;
+
+	if (idx < 0 || idx >= hostCacheCount)
+		return;
+
+	Menu_SetSound(MENU_SND_ENTER);
+
+	// on a failed/rejected connect, _Datagram_Connect restores this
+	// menu instead of leaving a dead scene
+	m_return_state = m_state;
+	m_return_onerror = true;
+
+	key_dest = key_game;
+	m_state = m_none;
+
+	// connect by cname ("xx:xx:xx:xx:xx:xx:port") — hostnames can
+	// collide, MACs cannot
+	Cbuf_AddText (va("connect \"%s\"\n", hostcache[idx].cname));
+}
+
+/*
+===============
+Menu_CoopJoin_Set
+===============
+*/
+void Menu_CoopJoin_Set (void)
+{
+	Menu_ResetMenuButtons();
+
+	key_dest = key_menu;
+	m_previous_state = m_coop;
+	m_state = m_coopjoin;
+
+	join_last_count = -1;
+	Menu_CoopJoin_StartScan();
+}
+
+/*
+===============
+Menu_CoopJoin_Draw
+===============
+*/
+void Menu_CoopJoin_Draw (void)
+{
+	int i;
+
+	// Background
+	Menu_DrawCustomBackground (true);
+
+	// Header
+	Menu_DrawTitle ("JOIN GAME", MENU_COLOR_WHITE);
+
+	// Version String
+	Menu_DrawBuildDate();
+
+	// the host cache fills asynchronously while the scan runs —
+	// rebuild the button slots whenever it grows AND when the scan
+	// finishes (the button layout changes between the two states)
+	if (join_last_count != hostCacheCount || join_last_scanning != slistInProgress) {
+		Menu_ResetMenuButtons();
+		join_last_count = hostCacheCount;
+		join_last_scanning = slistInProgress;
+	}
+
+	for (i = 0; i < hostCacheCount; i++) {
+		if (hostcache[i].maxusers)
+			snprintf(join_rows[i], sizeof(join_rows[i]), "%.15s (%.15s) %d/%d", hostcache[i].name, hostcache[i].map, hostcache[i].users, hostcache[i].maxusers);
+		else
+			snprintf(join_rows[i], sizeof(join_rows[i]), "%.15s (%.15s)", hostcache[i].name, hostcache[i].map);
+
+		Menu_DrawButton(i + 1, i, join_rows[i], "Join this Game.", Menu_CoopJoin_Connect);
+	}
+
+	if (slistInProgress) {
+		Menu_DrawGreyButton(hostCacheCount + 2, "SEARCHING...");
+		Menu_DrawButton(-1, hostCacheCount, "BACK", "Return to Cooperative Menu.", Menu_Coop_Set);
+	} else {
+		if (hostCacheCount == 0)
+			Menu_DrawGreyButton(2, "NO GAMES FOUND");
+
+		Menu_DrawButton(hostCacheCount + 3, hostCacheCount, "RESCAN", "Search again.", Menu_CoopJoin_StartScan);
+		Menu_DrawButton(-1, hostCacheCount + 1, "BACK", "Return to Cooperative Menu.", Menu_Coop_Set);
+	}
+
+	// why the last connect attempt bounced us back here
+	if (m_return_reason[0])
+		Menu_DrawGreyButton(hostCacheCount + 4, m_return_reason);
+}
+
+#endif // __PSP__

--- a/source/menu/menu_defs.h
+++ b/source/menu/menu_defs.h
@@ -47,6 +47,8 @@ extern int				m_previous_state;
 #define	m_slist			21
 #define m_bindings		22
 #define m_bios 			23
+#define m_coop			24
+#define m_coopjoin		25
 ///////////////////////////
 ///////////////////////////
 ///////////////////////////
@@ -311,6 +313,10 @@ void Menu_Audio_Set (void);
 void Menu_Controls_Set (void);
 void Menu_Bindings_Set (void);
 void Menu_Accessibility_Set (void);
+#ifdef __PSP__
+void Menu_Coop_Set (void);
+void Menu_CoopJoin_Set (void);
+#endif
 
 // Platform specifics
 char *LoadingScreen_ReturnTip(void);

--- a/source/menu/menu_helper.c
+++ b/source/menu/menu_helper.c
@@ -120,17 +120,33 @@ void Menu_LoadMap (char *selected_map)
 	char map_command[64];
 
 	for (i = 0; i < num_user_maps; i++) {
-		if (!strcmp(selected_map, custom_maps[i].map_name)) 
+		if (!strcmp(selected_map, custom_maps[i].map_name))
 			break;
 	}
 
 	map_loadname = current_selected_bsp;
-    map_loadname_pretty = custom_maps[i].map_name_pretty;
+	if (i < num_user_maps)
+		map_loadname_pretty = custom_maps[i].map_name_pretty;
+	else
+		map_loadname_pretty = selected_map;
 
 	key_dest = key_game;
 	if (sv.active) {
 		Cbuf_AddText ("disconnect\n");
 	}
+#ifdef __PSP__
+	if (!menu_is_solo) {
+		// hosting an AdHoc game: coop must be set BEFORE maxplayers
+		// (MaxPlayers_f forces deathmatch 1 otherwise)
+		Cbuf_AddText ("coop 1\n");
+		Cbuf_AddText ("maxplayers 4\n");
+		Cbuf_AddText ("listen 1\n");
+	} else {
+		// back to solo: stop listening and free the client slots
+		Cbuf_AddText ("coop 0\n");
+		Cbuf_AddText ("maxplayers 1\n");
+	}
+#endif
 	snprintf (map_command, sizeof(map_command), "map %s\n", map_loadname);
 	Cbuf_AddText (map_command);
 	LoadingScreen_Begin(map_loadname);

--- a/source/menu/menu_main.c
+++ b/source/menu/menu_main.c
@@ -69,6 +69,22 @@ void Menu_Main_Draw (void)
 
 	if (!in_submenu) {
 		Menu_DrawButton(1, 0, "SOLO", "Play Solo.", Menu_Solo);
+#ifdef __PSP__
+		Menu_DrawButton(2, 1, "COOPERATIVE", "Play with Friends over AdHoc.", Menu_Coop_Set);
+
+		Menu_DrawDivider(3);
+
+		Menu_DrawButton(3, 2, "CONFIGURATION", "Tweak Game Related Options", Menu_Configuration_Set);
+		Menu_DrawButton(4, 3, "CHARACTER BIOS", "View Character Bios", Menu_Bios_Set);
+
+		Menu_DrawDivider(5);
+
+		Menu_DrawButton(5, 4, "CREDITS", "NZ:P Team + Special Thanks", Menu_Credits_Set);
+
+		Menu_DrawDivider(6);
+
+		Menu_DrawButton(6, 5, "QUIT GAME", "Return to Home Screen", Menu_EnterSubMenu);
+#else
 		Menu_DrawGreyButton(2, "COOPERATIVE");
 
 		Menu_DrawDivider(3);
@@ -83,6 +99,7 @@ void Menu_Main_Draw (void)
 		Menu_DrawDivider(6);
 
 		Menu_DrawButton(6, 4, "QUIT GAME", "Return to Home Screen", Menu_EnterSubMenu);
+#endif
 
 		Menu_DrawSocialBadge (1, MENU_SOC_YOUTUBE);
 		Menu_DrawSocialBadge (2, MENU_SOC_BLUESKY);

--- a/source/menu/menu_pause.c
+++ b/source/menu/menu_pause.c
@@ -44,7 +44,7 @@ void Menu_Pause_EnterSubMenu(void)
 
 void Menu_Pause_Yes(void)
 {
-    if (menu_paus_submenu == 1) {
+    if (sv.active && menu_paus_submenu == 1) {
 		// User is restarting the map
 		menu_paus_submenu = 0;
 		key_dest = key_game;
@@ -56,8 +56,9 @@ void Menu_Pause_Yes(void)
 		}
 
 		SV_RestartServer ();
-	} else if (menu_paus_submenu == 3) {
-		// User is returning to Main Menu
+	} else if (menu_paus_submenu == 3 || (!sv.active && menu_paus_submenu == 2)) {
+		// User is returning to Main Menu (button index 2 in the
+		// remote-client layout, where RESTART LEVEL is greyed out)
 		menu_paus_submenu = 0;
 		// Exit the map
 		Menu_ExitMap();
@@ -105,14 +106,22 @@ void Menu_Pause_Draw (void)
 	Menu_DrawTitle ("PAUSED", MENU_COLOR_WHITE);
 
 	if (menu_paus_submenu == 0) {
-		// Resume
-		Menu_DrawButton (1, 0, "RESUME CARNAGE", "Return to Game.", Menu_Resume);
-		// Restart
-		Menu_DrawButton (2, 1, "RESTART LEVEL", "Tough luck? Give things another go.", Menu_Pause_EnterSubMenu);
-		// Options
-		Menu_DrawButton (3, 2, "OPTIONS", "Tweak Game related Options.", Menu_Configuration);
-		// End game
-		Menu_DrawButton (4, 3, "END GAME", "Return to Main Menu.", Menu_Pause_EnterSubMenu);
+		if (sv.active) {
+			// Resume
+			Menu_DrawButton (1, 0, "RESUME CARNAGE", "Return to Game.", Menu_Resume);
+			// Restart
+			Menu_DrawButton (2, 1, "RESTART LEVEL", "Tough luck? Give things another go.", Menu_Pause_EnterSubMenu);
+			// Options
+			Menu_DrawButton (3, 2, "OPTIONS", "Tweak Game related Options.", Menu_Configuration);
+			// End game
+			Menu_DrawButton (4, 3, "END GAME", "Return to Main Menu.", Menu_Pause_EnterSubMenu);
+		} else {
+			// Remote client: restarting the level is the host's call
+			Menu_DrawButton (1, 0, "RESUME CARNAGE", "Return to Game.", Menu_Resume);
+			Menu_DrawGreyButton (2, "RESTART LEVEL");
+			Menu_DrawButton (3, 1, "OPTIONS", "Tweak Game related Options.", Menu_Configuration);
+			Menu_DrawButton (4, 2, "END GAME", "Disconnect and return to Main Menu.", Menu_Pause_EnterSubMenu);
+		}
 	} else {
 		Menu_DrawGreyButton (1,"RESUME CARNAGE");
 		Menu_DrawGreyButton (2, "RESTART LEVEL");
@@ -120,9 +129,9 @@ void Menu_Pause_Draw (void)
 		Menu_DrawGreyButton (4, "END GAME");
 
 		// Draw Sub Menu
-		if (menu_paus_submenu == 1) {
+		if (sv.active && menu_paus_submenu == 1) {
 			Menu_DrawSubMenu("Are you sure you want to restart?", "You will lose any progress that you have made.");
-		} else if (menu_paus_submenu == 3) {
+		} else if (menu_paus_submenu == 3 || (!sv.active && menu_paus_submenu == 2)) {
 			Menu_DrawSubMenu("Are you sure you want to quit?", "You will lose any progress that you have made.");
 		}
     

--- a/source/menu/menu_stockmaps.c
+++ b/source/menu/menu_stockmaps.c
@@ -38,7 +38,11 @@ void Menu_StockMaps_SetRandomMap (void)
     Menu_Lobby_Set();
 }
 
+#ifdef __PSP__
+void Menu_StockMaps_SetMainMenu (void) { if (menu_is_solo) {Menu_Main_Set();} else {Menu_Coop_Set();} };
+#else
 void Menu_StockMaps_SetMainMenu (void) { if (menu_is_solo) {Menu_Main_Set();} };
+#endif
 
 /*
 =======================
@@ -48,9 +52,13 @@ Menu_SinglePlayer_Set
 void Menu_StockMaps_Set (void)
 {
     Menu_ResetMenuButtons();
-    
+
     key_dest = key_menu;
+#ifdef __PSP__
+    m_previous_state = menu_is_solo ? m_main : m_coop;
+#else
     m_previous_state = m_main;
+#endif
 	m_state = m_stockmaps;
 }
 

--- a/source/menu/menu_sys.c
+++ b/source/menu/menu_sys.c
@@ -319,6 +319,14 @@ void Menu_SetPreviousMenu (void)
 		case m_accessibility:
 			Menu_Accessibility_Set();
 			break;
+#ifdef __PSP__
+		case m_coop:
+			Menu_Coop_Set();
+			break;
+		case m_coopjoin:
+			Menu_CoopJoin_Set();
+			break;
+#endif
 	}
 }
 

--- a/source/nzportable_def.h
+++ b/source/nzportable_def.h
@@ -152,6 +152,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define STAT_VIEWMODEL2_EFFECTS 22
 #define STAT_GUNGAME_IDX		23
 #define STAT_GUNGAME_SCOREGOAL	24
+#define STAT_MAXSPEED			25
+#define STAT_FACINGENEMY		26
 
 // Gamemodes 
 #define GAMEMODE_CLASSIC        0

--- a/source/platform/ctr/gl/gl_draw.c
+++ b/source/platform/ctr/gl/gl_draw.c
@@ -899,7 +899,7 @@ void Draw_Crosshair (void)
 		Draw_Pic (-39, -15, sniper_scope);
 	}
 
-   	if (Hitmark_Time > sv.time) {
+   	if (Hitmark_Time > cl.time) {
         Draw_Pic ((vid.width - gltextures[hitmark].width)/2,(vid.height - gltextures[hitmark].height)/2, hitmark);
 	}
 
@@ -919,7 +919,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -928,7 +928,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-	else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+	else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;

--- a/source/platform/ctr/screen.h
+++ b/source/platform/ctr/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 int GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 

--- a/source/platform/nspire/draw.c
+++ b/source/platform/nspire/draw.c
@@ -1886,7 +1886,7 @@ void Draw_Crosshair (void)
 	if (cl.stats[STAT_ZOOM] == 2)
 		Draw_Pic (0, 0, sniper_scope);
 
-   	if (Hitmark_Time > sv.time)
+   	if (Hitmark_Time > cl.time)
         Draw_Pic ((vid.width - tex->width)/2,(vid.height - tex->height)/2, hitmark);
 
 	// Make sure to do this after hitmark drawing.
@@ -1905,7 +1905,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -1914,7 +1914,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-    else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+    else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;

--- a/source/platform/nspire/screen.c
+++ b/source/platform/nspire/screen.c
@@ -242,7 +242,7 @@ char *GetPerkName (int perk)
 	}
 }
 
-void SCR_UsePrint (int type, int cost, int weapon)
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name)
 {
 	//naievil -- fixme
     char s[128];
@@ -265,12 +265,12 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 3://ammo
-			strcpy(s, va("Hold     to buy Ammo for %s\n", PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, va("Hold     to buy Ammo for %s\n", weapon_name));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 4://weapon
-			strcpy(s, va("Hold     to buy %s\n", PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, va("Hold     to buy %s\n", weapon_name));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
@@ -285,7 +285,7 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 7://box take
-			strcpy(s, va("Hold     for %s\n", PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, va("Hold     for %s\n", weapon_name));
 			strcpy(c, "");
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;

--- a/source/platform/nspire/screen.h
+++ b/source/platform/nspire/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 int GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 

--- a/source/platform/nx/gl/gl_draw.c
+++ b/source/platform/nx/gl/gl_draw.c
@@ -884,7 +884,7 @@ void Draw_Crosshair (void)
 		Draw_Pic (-39, -15, sniper_scope);
 	}
 
-   	if (Hitmark_Time > sv.time) {
+   	if (Hitmark_Time > cl.time) {
         Draw_Pic ((vid.width - gltextures[hitmark].width)/2,(vid.height - gltextures[hitmark].height)/2, hitmark);
 	}
 
@@ -904,7 +904,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -913,7 +913,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-	else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+	else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;

--- a/source/platform/nx/screen.h
+++ b/source/platform/nx/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 int GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 

--- a/source/platform/psp/gu/gu_QMB.cpp
+++ b/source/platform/psp/gu/gu_QMB.cpp
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern "C"
 {
 #include "../../../nzportable_def.h"
+
+extern float cl_flash_size; // svc_weapondata, cl_parse.c
 //entity_t *CL_NewTempEntity (void);
 }
 
@@ -2313,7 +2315,9 @@ void QMB_MuzzleFlash(vec3_t org)
 
 	if(!(ISUNDERWATER(TruePointContents(org))))
 	{
-		size = sv_player->v.Flash_Size;
+		// per-weapon flash size replicated via svc_weapondata — valid
+		// on the listen host and on remote clients alike
+		size = cl_flash_size;
 
 		if(size == 0 || cl.stats[STAT_ZOOM] == 2)
 			return;

--- a/source/platform/psp/gu/gu_draw.cpp
+++ b/source/platform/psp/gu/gu_draw.cpp
@@ -1122,7 +1122,7 @@ extern "C" void Draw_Crosshair (void)
 		Draw_FillByColor(368, 7, 112, 256, 0, 0, 0, 255); // Right
 	}
 		
-   	if (Hitmark_Time > sv.time)
+   	if (Hitmark_Time > cl.time)
 		Draw_ColoredStretchPic ((vid.width - 16)/2, (vid.height - 16)/2, hitmark, 16, 16, 255, 255, 255, 225);
 
 	// Make sure to do this after hitmark drawing.
@@ -1134,14 +1134,16 @@ extern "C" void Draw_Crosshair (void)
 
 	float col;
 
-	if (sv_player->v.facingenemy == 1) {
+	// replicated via STAT_FACINGENEMY — valid for the local player on
+	// host and remote clients alike (sv_player is neither)
+	if (cl.stats[STAT_FACINGENEMY] == 1) {
 		col = 0;
 	} else {
 		col = 255;
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -1150,7 +1152,7 @@ extern "C" void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-    else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+    else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;
@@ -1175,9 +1177,11 @@ extern "C" void Draw_Crosshair (void)
 		if (CrossHairMaxSpread() < crosshair_offset || croshhairmoving)
 			crosshair_offset = CrossHairMaxSpread();
 
-		if (sv_player->v.view_ofs[2] == 8) {
+		// cl.viewheight mirrors the player's view_ofs[2] via
+		// svc_clientdata, so it is correct on remote clients too
+		if (cl.viewheight == 8) {
 			crosshair_offset *= 0.80;
-		} else if (sv_player->v.view_ofs[2] == -10) {
+		} else if (cl.viewheight == -10) {
 			crosshair_offset *= 0.65;
 		}
 

--- a/source/platform/psp/net_dgrm.c
+++ b/source/platform/psp/net_dgrm.c
@@ -29,6 +29,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define sfunc	net_landrivers[sock->landriver]
 #define dfunc	net_landrivers[net_landriverlevel]
 
+// AdHoc PDP datagrams travel as single 802.11/UDP frames with no
+// reliable fragmentation underneath (PPSSPP forwards each PdpSend as
+// one UDP packet) — keep each packet under the WiFi MTU there. Big
+// 8000-byte chunks work on loopback but die on real links.
+#define DGRM_ADHOC_MTU		1400
+#define DGRM_MAX_PAYLOAD	(tcpipAdhoc ? DGRM_ADHOC_MTU : MAX_DATAGRAM)
+
 static int net_landriverlevel;
 
 int net_driver_to_use;
@@ -95,14 +102,14 @@ int Datagram_SendMessage (qsocket_t *sock, sizebuf_t *data)
 	Q_memcpy(sock->sendMessage, data->data, data->cursize);
 	sock->sendMessageLength = data->cursize;
 
-	if (data->cursize <= MAX_DATAGRAM)
+	if (data->cursize <= DGRM_MAX_PAYLOAD)
 	{
 		dataLen = data->cursize;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = DGRM_MAX_PAYLOAD;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
@@ -128,14 +135,14 @@ int SendMessageNext (qsocket_t *sock)
 	unsigned int	dataLen;
 	unsigned int	eom;
 
-	if (sock->sendMessageLength <= MAX_DATAGRAM)
+	if (sock->sendMessageLength <= DGRM_MAX_PAYLOAD)
 	{
 		dataLen = sock->sendMessageLength;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = DGRM_MAX_PAYLOAD;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
@@ -161,14 +168,14 @@ int ReSendMessage (qsocket_t *sock)
 	unsigned int	dataLen;
 	unsigned int	eom;
 
-	if (sock->sendMessageLength <= MAX_DATAGRAM)
+	if (sock->sendMessageLength <= DGRM_MAX_PAYLOAD)
 	{
 		dataLen = sock->sendMessageLength;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = DGRM_MAX_PAYLOAD;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
@@ -329,16 +336,25 @@ int	Datagram_GetMessage (qsocket_t *sock)
 				Con_DPrintf("Duplicate ACK received\n");
 				continue;
 			}
-			sock->sendMessageLength -= MAX_DATAGRAM;
-			if (sock->sendMessageLength > 0)
+			// advance by the size of the chunk that was actually
+			// sent (DGRM_MAX_PAYLOAD-sized, smaller for the tail) —
+			// the classic fixed MAX_DATAGRAM stride only works when
+			// chunks are always MAX_DATAGRAM bytes
 			{
-				Q_memcpy(sock->sendMessage, sock->sendMessage+MAX_DATAGRAM, sock->sendMessageLength);
-				sock->sendNext = true;
-			}
-			else
-			{
-				sock->sendMessageLength = 0;
-				sock->canSend = true;
+				int acked = (sock->sendMessageLength <= DGRM_MAX_PAYLOAD)
+					? sock->sendMessageLength : DGRM_MAX_PAYLOAD;
+
+				sock->sendMessageLength -= acked;
+				if (sock->sendMessageLength > 0)
+				{
+					Q_memcpy(sock->sendMessage, sock->sendMessage+acked, sock->sendMessageLength);
+					sock->sendNext = true;
+				}
+				else
+				{
+					sock->sendMessageLength = 0;
+					sock->canSend = true;
+				}
 			}
 			continue;
 		}
@@ -681,9 +697,13 @@ int Datagram_Init ()
 	int i;
 	int csock;
 
-	myDriverLevel = net_driverlevel;
+	// only latch the driver level at boot (NET_Init) — later re-inits
+	// come from the coop menu, where net_driverlevel is stale
 	if(!host_initialized)
+	{
+		myDriverLevel = net_driverlevel;
 		Cmd_AddCommand ("net_stats", NET_Stats_f);
+	}
 
 	if (COM_CheckParm("-nolan"))
 		return -1;
@@ -1104,11 +1124,29 @@ static qsocket_t *_Datagram_Connect (char *host)
 
 	// see if we can resolve the host name
 	if (dfunc.GetAddrFromName(host, &sendaddr) == -1)
+	{
+		Q_strcpy(m_return_reason, "Bad address");
+		if (m_return_onerror)
+		{
+			key_dest = key_menu;
+			m_state = m_return_state;
+			m_return_onerror = false;
+		}
 		return NULL;
+	}
 
 	newsock = dfunc.OpenSocket (0);
 	if (newsock == -1)
+	{
+		Q_strcpy(m_return_reason, "No free sockets");
+		if (m_return_onerror)
+		{
+			key_dest = key_menu;
+			m_state = m_return_state;
+			m_return_onerror = false;
+		}
 		return NULL;
+	}
 
 	sock = NET_NewQSocket ();
 	if (sock == NULL)

--- a/source/platform/psp/network_psp.cpp
+++ b/source/platform/psp/network_psp.cpp
@@ -82,7 +82,7 @@ pdpStatStruct *findPdpStat(int socket, pdpStatStruct *pdpStat)
 		return &gPdpStat;
 	}
 		if(pdpStat->next) return findPdpStat(socket, pdpStat->next);
-		return (pdpStatStruct *)-1;
+		return NULL;
 }
 
 
@@ -612,10 +612,14 @@ namespace quake
 
 				S_ClearBuffer ();
 
-				sceUtilityLoadNetModule(PSP_NET_MODULE_COMMON);
-				sceUtilityLoadNetModule(PSP_NET_MODULE_ADHOC);
+				const int err1 = sceUtilityLoadNetModule(PSP_NET_MODULE_COMMON);
+				if(err1 < 0)
+					Con_Printf("Couldn't load MODULE_COMMON: %08x\n", err1);
+				const int err2 = sceUtilityLoadNetModule(PSP_NET_MODULE_ADHOC);
+				if(err2 < 0)
+					Con_Printf("Couldn't load MODULE_ADHOC: %08x\n", err2);
 
-				int stateLast = -1;
+				int timeout = 0;
 				rc = pspSdkAdhocInit("ULUS00443");
 				if(rc < 0) {
 					Con_Printf("Couldn't initialise the network %08X\n", rc);
@@ -624,7 +628,11 @@ namespace quake
 					return -1;
 				}
 
-				rc = sceNetAdhocctlConnect((const char *)"quake");
+				// NOTE: group name intentionally differs from v1's "quake" —
+				// v1 shares NET_PROTOCOL_VERSION/PROTOCOL_VERSION with 2.x but
+				// has an incompatible svc set, so the builds must not discover
+				// each other.
+				rc = sceNetAdhocctlConnect((const char *)"nzp2");
 				if(rc < 0) {
 					Con_Printf("Couldn't initialise the network %08X\n", rc);
 					pspSdkAdhocTerm();
@@ -643,13 +651,18 @@ namespace quake
 						sceUtilityUnloadNetModule(PSP_NET_MODULE_COMMON);
 						return -1;
 					}
-					if (state > stateLast) {
-						stateLast = state;
-					}
 					if (state == 1) {
 						break;
 					}
 					sceKernelDelayThread(50*1000); // 50ms
+
+					if (++timeout > 200) { // ~10 seconds
+						Con_Printf("Timeout joining adhoc group\n");
+						pspSdkAdhocTerm();
+						sceUtilityUnloadNetModule(PSP_NET_MODULE_ADHOC);
+						sceUtilityUnloadNetModule(PSP_NET_MODULE_COMMON);
+						return -1;
+					}
 				}
 
 				gethostname(buff, MAXHOSTNAMELEN);
@@ -751,12 +764,13 @@ namespace quake
 				if (accept_socket == -1)
 					return -1;
 
+				memset(pdpStat, 0, sizeof(pdpStat));
 				int err = sceNetAdhocGetPdpStat(&length, pdpStat);
-				if(err < 0) return -1;
+				if(err < 0 || length == 0) return -1;
 
 				pdpStatStruct *tempPdp = findPdpStat(accept_socket, pdpStat);
 
-				if(tempPdp->pdpId < 0) return -1;
+				if(!tempPdp) return -1;
 
 				if(tempPdp->rcvdData > 0) return accept_socket;
 
@@ -769,12 +783,13 @@ namespace quake
 			{
 				unsigned short port;
 				int datalength = len;
-				unsigned int ret;
+				int ret;
 
 				sceKernelDelayThread(1);
 
 				ret = sceNetAdhocPdpRecv(socket, (unsigned char *)((sockaddr_adhoc *)addr)->mac, &port, buf, &datalength, 0, 1);
-				if(ret == ADHOC_EWOULDBLOCK) return 0;
+				if((unsigned int)ret == ADHOC_EWOULDBLOCK) return 0;
+				if(ret < 0) return -1;
 
 				((sockaddr_adhoc *)addr)->port = port;
 
@@ -817,8 +832,9 @@ namespace quake
 				int ret = -1;
 
 				ret = sceNetAdhocPdpSend(socket, (unsigned char*)((sockaddr_adhoc *)addr)->mac, ((sockaddr_adhoc *)addr)->port, buf, len, 0, 1);
+				if((unsigned int)ret == ADHOC_EWOULDBLOCK) return 0;
+				if(ret < 0) return -1;
 
-				//if(ret < 0) Con_Printf("Failed to send message, errno=%08X\n", ret);//blubs
 				return ret;
 			}
 
@@ -826,7 +842,7 @@ namespace quake
 
 			char* addr_to_string (struct qsockaddr *addr)
 			{
-				static char buffer[22];
+				static char buffer[32]; // "aa:bb:cc:dd:ee:ff" + ":65535" + NUL
 
 				sceNetEtherNtostr((unsigned char *)((sockaddr_adhoc *)addr)->mac, buffer);
 				sprintf(buffer + strlen(buffer), ":%d", ((sockaddr_adhoc *)addr)->port);
@@ -839,7 +855,9 @@ namespace quake
 			{
 				int ha1, ha2, ha3, ha4, ha5, ha6, hp;
 
-				sscanf(string, "%x:%x:%x:%x:%x:%x:%d", &ha1, &ha2, &ha3, &ha4, &ha5, &ha6, &hp);
+				int r = sscanf(string, "%x:%x:%x:%x:%x:%x:%d", &ha1, &ha2, &ha3, &ha4, &ha5, &ha6, &hp);
+				if (r < 6) return -1;
+				if (r < 7) hp = net_hostport;
 				addr->sa_family = ADHOC_NET;
 				((struct sockaddr_adhoc *)addr)->mac[0] = ha1 & 0xFF;
 				((struct sockaddr_adhoc *)addr)->mac[1] = ha2 & 0xFF;
@@ -858,11 +876,12 @@ namespace quake
 				pdpStatStruct pdpStat[20];
 				int length = sizeof(pdpStatStruct) * 20;
 
+				memset(pdpStat, 0, sizeof(pdpStat));
 				int err = sceNetAdhocGetPdpStat(&length, pdpStat);
-				if(err<0) return -1;
+				if(err < 0 || length == 0) return -1;
 
 				pdpStatStruct *tempPdp = findPdpStat(socket, pdpStat);
-				if(tempPdp->pdpId < 0) return -1;
+				if(!tempPdp) return -1;
 
 				memcpy_vfpu(((struct sockaddr_adhoc *)addr)->mac, tempPdp->mac, 6);
 				((struct sockaddr_adhoc *)addr)->port = tempPdp->port;
@@ -911,22 +930,30 @@ namespace quake
 
 			//=============================================================================
 
-			int pspSdkAdhocInit(char *product)
+			int pspSdkAdhocInit(const char *product)
 			{
-				u32 retVal;
+				int retVal;
 				struct productStruct temp;
 
 				retVal = sceNetInit(0x20000, 0x20, 0x1000, 0x20, 0x1000);
 				if (retVal != 0) return retVal;
 
 				retVal = sceNetAdhocInit();
-				if (retVal != 0) return retVal;
+				if (retVal != 0) {
+					sceNetTerm();
+					return retVal;
+				}
 
-				strcpy(temp.product, product);
+				memset(temp.product, 0, sizeof(temp.product));
+				memcpy(temp.product, product, strlen(product) > sizeof(temp.product) ? sizeof(temp.product) : strlen(product));
 				temp.unknown = 0;
 
 				retVal = sceNetAdhocctlInit(0x2000, 0x20, &temp);
-				if (retVal != 0) return retVal;
+				if (retVal != 0) {
+					sceNetAdhocTerm();
+					sceNetTerm();
+					return retVal;
+				}
 
 				return 0;
 			}
@@ -935,6 +962,7 @@ namespace quake
 
 			void pspSdkAdhocTerm()
 			{
+				sceNetAdhocctlDisconnect();
 				sceNetAdhocctlTerm();
 				sceNetAdhocTerm();
 				sceNetTerm();

--- a/source/platform/psp/network_psp.hpp
+++ b/source/platform/psp/network_psp.hpp
@@ -75,7 +75,7 @@ namespace quake
 			int  addr_compare (struct qsockaddr *addr1, struct qsockaddr *addr2);
 			int  get_socket_port (struct qsockaddr *addr);
 			int  set_socket_port (struct qsockaddr *addr, int port);
-			int pspSdkAdhocInit(char *product);
+			int pspSdkAdhocInit(const char *product);
 			void pspSdkAdhocTerm();
 		}
 	}

--- a/source/platform/psp/screen.h
+++ b/source/platform/psp/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 int GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 char *GetUseButtonL();

--- a/source/platform/psp2/gl/gl_draw.c
+++ b/source/platform/psp2/gl/gl_draw.c
@@ -884,7 +884,7 @@ void Draw_Crosshair (void)
 		Draw_Pic (-39, -15, sniper_scope);
 	}
 
-   	if (Hitmark_Time > sv.time) {
+   	if (Hitmark_Time > cl.time) {
         Draw_Pic ((vid.width - gltextures[hitmark].width)/2,(vid.height - gltextures[hitmark].height)/2, hitmark);
 	}
 
@@ -904,7 +904,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -913,7 +913,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-	else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+	else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;

--- a/source/platform/psp2/screen.h
+++ b/source/platform/psp2/screen.h
@@ -29,7 +29,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 
 void SCR_BeginLoadingPlaque (void);
 void SCR_EndLoadingPlaque (void);

--- a/source/platform/rvl/gx/gx_draw.c
+++ b/source/platform/rvl/gx/gx_draw.c
@@ -1212,7 +1212,7 @@ void Draw_Crosshair (void)
 		}
 	}
 	
-   	if (Hitmark_Time > sv.time) {
+   	if (Hitmark_Time > cl.time) {
 		
 		if ((cl.stats[STAT_ZOOM] == 1 && ads_center.value) || (cl.stats[STAT_ZOOM] == 2 && sniper_center.value)) {
 			Draw_ColoredStretchPic ((vid.width - 12)/2, (vid.height - 12)/2, hitmark, 24, 24, 255, 255, 255, 225);
@@ -1237,7 +1237,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if ((crosshair_spread_time > sv.time && crosshair_spread_time) || croshhairmoving == true)
+	if ((crosshair_spread_time > cl.time && crosshair_spread_time) || croshhairmoving == true)
     {
         cur_spread = cur_spread + 4;
 		if (cur_spread >= CrossHairMaxSpread())
@@ -1248,7 +1248,7 @@ void Draw_Crosshair (void)
 			crosshair_opacity = 155;
     }
 	// crosshair not moving
-    else if ((crosshair_spread_time < sv.time && crosshair_spread_time) || croshhairmoving == false)
+    else if ((crosshair_spread_time < cl.time && crosshair_spread_time) || croshhairmoving == false)
     {
         cur_spread = cur_spread - 2;
 		if (cur_spread <= 0) {

--- a/source/platform/rvl/gx/gx_screen.c
+++ b/source/platform/rvl/gx/gx_screen.c
@@ -405,7 +405,7 @@ char *GetPerkName (int perk)
 	}
 }
 
-void SCR_UsePrint (int type, int cost, int weapon)
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name)
 {
 	//naievil -- fixme
     char s[128];
@@ -428,12 +428,12 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold", 1.5);
 			break;
 		case 3://ammo
-			strcpy(s, va("Hold %s to buy Ammo for %s\n", GetUseButtonL(), pr_strings+sv_player->v.Weapon_Name_Touch));
+			strcpy(s, va("Hold %s to buy Ammo for %s\n", GetUseButtonL(), weapon_name));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold", 1.5);
 			break;
 		case 4://weapon
-			strcpy(s, va("Hold %s to buy %s\n", GetUseButtonL(), pr_strings+sv_player->v.Weapon_Name_Touch));
+			strcpy(s, va("Hold %s to buy %s\n", GetUseButtonL(), weapon_name));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold", 1.5);
 			break;
@@ -448,7 +448,7 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold", 1.5);
 			break;
 		case 7://box take
-			strcpy(s, va("Hold %s for %s\n", GetUseButtonL(), pr_strings+sv_player->v.Weapon_Name_Touch));
+			strcpy(s, va("Hold %s for %s\n", GetUseButtonL(), weapon_name));
 			strcpy(c, "");
 			button_pic_x = getTextWidth("Hold", 1.5);
 			break;

--- a/source/platform/rvl/screen.h
+++ b/source/platform/rvl/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 qpic_t *GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 void SCR_BeginLoadingPlaque (void);

--- a/source/platform/sdl/gl/gl_draw.c
+++ b/source/platform/sdl/gl/gl_draw.c
@@ -884,7 +884,7 @@ void Draw_Crosshair (void)
 		Draw_Pic (-39, -15, sniper_scope);
 	}
 
-   	if (Hitmark_Time > sv.time) {
+   	if (Hitmark_Time > cl.time) {
         Draw_Pic ((vid.width - gltextures[hitmark].width)/2,(vid.height - gltextures[hitmark].height)/2, hitmark);
 	}
 
@@ -904,7 +904,7 @@ void Draw_Crosshair (void)
 	}
 
 	// crosshair moving
-	if (crosshair_spread_time > sv.time && crosshair_spread_time)
+	if (crosshair_spread_time > cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread + 10;
 		crosshair_opacity = 128;
@@ -913,7 +913,7 @@ void Draw_Crosshair (void)
 			cur_spread = CrossHairMaxSpread();
     }
 	// crosshair not moving
-	else if (crosshair_spread_time < sv.time && crosshair_spread_time)
+	else if (crosshair_spread_time < cl.time && crosshair_spread_time)
     {
         cur_spread = cur_spread - 4;
 		crosshair_opacity = 255;

--- a/source/platform/sdl/screen.h
+++ b/source/platform/sdl/screen.h
@@ -28,7 +28,7 @@ void SCR_SizeUp (void);
 void SCR_SizeDown (void);
 void SCR_BringDownConsole (void);
 void SCR_CenterPrint (char *str);
-void SCR_UsePrint (int type, int cost, int weapon);
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name);
 int GetButtonIcon (char *buttonname);
 char *GetGrenadeButtonL();
 

--- a/source/pr_cmds.c
+++ b/source/pr_cmds.c
@@ -389,7 +389,9 @@ void PF_useprint (void)
 	MSG_WriteByte (&client->message,type);
 	MSG_WriteShort (&client->message,cost);
 	MSG_WriteByte (&client->message,weapon);
-	//MSG_WriteString (&client->message, s );
+	// touched-weapon name for the buy prompt — progs strings are not
+	// readable on remote clients
+	MSG_WriteString (&client->message, PR_GetString(G_EDICT(OFS_PARM0)->v.Weapon_Name_Touch));
 }
 
 

--- a/source/protocol.h
+++ b/source/protocol.h
@@ -19,7 +19,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // protocol.h -- communications protocols
 
-#define	PROTOCOL_VERSION	15
+// 16: svc_clientdata carries maxspeed + facingenemy for remote clients
+// (also keeps legacy v1 builds, which are protocol 15 with a different
+// svc set, from cross-connecting)
+#define	PROTOCOL_VERSION	16
 
 // if the high bit of the servercmd is set, the low bits are fast update flags:
 #define	U_MOREBITS	(1<<0)
@@ -164,6 +167,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_gamemode		53		// [byte] game mode for client
 #define svc_roundcolor		54 		// [byte] red [byte] green [byte] blue
 #define svc_perkorientation 55		// [byte] Perk orientation for HUD
+#define svc_weapondata		56		// [string] weapon name, [short*3] ADS offset,
+									// [short*3] flash offset, [short] flash size —
+									// per-weapon client visuals, sent on weapon change
+									// (remote clients cannot read the host's progs)
 
 //
 // client to server

--- a/source/render/r_screen.c
+++ b/source/render/r_screen.c
@@ -400,7 +400,7 @@ char *GetPerkName (int perk)
 	}
 }
 
-void SCR_UsePrint (int type, int cost, int weapon)
+void SCR_UsePrint (int type, int cost, int weapon, char *weapon_name)
 {
 	//naievil -- fixme
     char s[128];
@@ -423,12 +423,12 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 3://ammo
-			strcpy(s, va("Hold %s to buy Ammo for %s\n", GetUseButtonL(), PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, weapon_name[0] ? va("Hold %s to buy Ammo for %s\n", GetUseButtonL(), weapon_name) : va("Hold %s to buy Ammo\n", GetUseButtonL()));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 4://weapon
-			strcpy(s, va("Hold %s to buy %s\n", GetUseButtonL(), PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, weapon_name[0] ? va("Hold %s to buy %s\n", GetUseButtonL(), weapon_name) : va("Hold %s to buy\n", GetUseButtonL()));
 			strcpy(c, va("[Cost: %i]\n", cost));
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
@@ -443,7 +443,7 @@ void SCR_UsePrint (int type, int cost, int weapon)
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;
 		case 7://box take
-			strcpy(s, va("Hold %s for %s\n", GetUseButtonL(), PR_GetString(sv_player->v.Weapon_Name_Touch)));
+			strcpy(s, weapon_name[0] ? va("Hold %s for %s\n", GetUseButtonL(), weapon_name) : va("Hold %s to take Weapon\n", GetUseButtonL()));
 			strcpy(c, "");
 			button_pic_x = getTextWidth("Hold ", 1);
 			break;

--- a/source/server.h
+++ b/source/server.h
@@ -103,6 +103,7 @@ typedef struct client_s
 // client known data for deltas
 	int				old_points;
 	int				old_kills;
+	int				old_weaponid;		// last weapon svc_weapondata was sent for
 // joe, from ProQuake: allow clients to connect if they don't have the map
 	qboolean	nomap;
 } client_t;

--- a/source/sv_main.c
+++ b/source/sv_main.c
@@ -254,6 +254,7 @@ void SV_SendServerinfo (client_t *client)
 
 	client->sendsignon = true;
 	client->spawned = false;		// need prespawn, spawn, etc
+	client->old_weaponid = -1;		// resend svc_weapondata after (re)connect
 }
 
 /*
@@ -812,6 +813,10 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 
 	MSG_WriteByte (msg, ent->v.gungame_weapon_idx);
 	MSG_WriteShort (msg, ent->v.gungame_score_threshold);
+	// movement speed + aim-assist state for remote clients (sv_player
+	// is not available off-host)
+	MSG_WriteShort (msg, ent->v.maxspeed);
+	MSG_WriteByte (msg, ent->v.facingenemy);
 }
 
 /*
@@ -891,7 +896,7 @@ void SV_UpdateToReliableMessages (void)
 				MSG_WriteShort (&client->message, host_client->edict->v.kills);
 			}
 
-			host_client->old_points = host_client->edict->v.points;
+			host_client->old_kills = host_client->edict->v.kills;
 		}
 	}
 
@@ -950,6 +955,25 @@ void SV_SendClientMessages (void)
 
 		if (host_client->spawned)
 		{
+			// per-weapon client visuals (name, ADS/flash offsets) live
+			// in the progs, which remote clients cannot read — send
+			// them reliably whenever this client's weapon changes
+			if ((int)host_client->edict->v.weapon != host_client->old_weaponid &&
+			    host_client->message.maxsize - host_client->message.cursize > 96)
+			{
+				edict_t *ed = host_client->edict;
+				int k;
+
+				MSG_WriteByte (&host_client->message, svc_weapondata);
+				MSG_WriteString (&host_client->message, PR_GetString(ed->v.Weapon_Name));
+				for (k = 0; k < 3; k++)
+					MSG_WriteShort (&host_client->message, (int)ed->v.ADS_Offset[k]);
+				for (k = 0; k < 3; k++)
+					MSG_WriteShort (&host_client->message, (int)ed->v.Flash_Offset[k]);
+				MSG_WriteShort (&host_client->message, (int)ed->v.Flash_Size);
+				host_client->old_weaponid = (int)ed->v.weapon;
+			}
+
 			if (!SV_SendClientDatagram (host_client))
 				continue;
 		}

--- a/source/view.c
+++ b/source/view.c
@@ -990,7 +990,7 @@ void DropRecoilKick (void)
 {
 	float	len;
 
-	if (crosshair_spread_time > sv.time)
+	if (crosshair_spread_time > cl.time)
 		return;
 	len = VectorNormalize (cl.gun_kick);
 
@@ -1110,9 +1110,12 @@ void V_CalcRefdef (void)
 	vec3_t ADSOffset;
 	if(cl.stats[STAT_ZOOM] == 1 || cl.stats[STAT_ZOOM] == 2)
 	{
-		ADSOffset[0] = sv_player->v.ADS_Offset[0];
-		ADSOffset[1] = sv_player->v.ADS_Offset[1];
-		ADSOffset[2] = sv_player->v.ADS_Offset[2];
+		// per-weapon ADS offset replicated via svc_weapondata — valid
+		// on the listen host and on remote clients alike
+		extern float cl_ads_offset[3];
+		ADSOffset[0] = cl_ads_offset[0];
+		ADSOffset[1] = cl_ads_offset[1];
+		ADSOffset[2] = cl_ads_offset[2];
 		
 		ADSOffset[0] = ADSOffset[0]/1000;
 		ADSOffset[1] = ADSOffset[1]/1000;


### PR DESCRIPTION
## What this is

The AdHoc landriver has been sitting dormant in the 2.x codebase (fully implemented in `network_psp.cpp`, registered in `network.cpp`, libs already linked) but nothing activated it — and several latent engine bugs made any real (non-loopback) multiplayer session crash or stall. This PR activates AdHoc behind a new **COOPERATIVE** menu on PSP and fixes the underlying netcode. It pairs with nzp-team/quakec PR "Standard build: fix mid-round join and unknown-gamemode crash" (one-line SpectatorSpawn fix) for the full experience, but is functional without it.

**Validated end-to-end on PPSSPP**: Linux desktop (host) ↔ Android phone (client) over LAN through the built-in AdHoc server, plus two-instance local testing — browse, join, mid-round spectator entry, spawn on round change, multi-player scoreboard/HUD, and host game-over → auto-restart with a connected client. Real-PSP testing is still pending (no hardware on hand) — testers welcome!

## The three root-cause bugs (why MP always black-screened/crashed)

1. **`CL_KeepaliveMessage` stack smash** — it kept an 8192-byte copy buffer, but `net_message.cursize` goes up to `NET_MAXMESSAGE` (16384) since the 2.x bump; NDU's serverinfo is 8426 bytes. The overflow overwrote the return address with precache-string bytes → the infamous deterministic `Bad Execution Address 0x61722f63` ("c/ra" in ASCII, from `...misc/radio.wav`). Never fired in solo because the function early-returns when `sv.active`.
2. **Reliable-ACK stride mismatch** — the dgrm ACK handler advanced the send buffer by a fixed `MAX_DATAGRAM`; with MTU-limited chunks the reassembled stream skipped bytes mid-message, corrupting the precache list (`models/pu/maxammo!.m` + `sounds/weapons/garand/clippush.wav` spliced together → client tried to load a WAV as a BSP).
3. **8000-byte PDP datagrams on real links** — AdHoc PDP sends travel as single frames (PPSSPP forwards each PdpSend as one UDP packet); 8KB reliable chunks fragment and die on real WiFi. Reliable chunks are now capped at 1400 bytes when `tcpipAdhoc` is active (unreliable snapshots unchanged).

## Remote-client correctness

The client code read server-side data that only exists on the listen host — instant NULL deref for a joining client, and (subtly) *wrong-player* data on a multi-client host, because `sv_player` points at the **last client the server processed**, not the local player:

- Movement speed and aim-assist state now replicate via new stats (`STAT_MAXSPEED`, `STAT_FACINGENEMY`) in `svc_clientdata` — correct on host and clients alike.
- Per-weapon client visuals (HUD weapon name, ADS offset, muzzle flash offset/size) replicate via a new on-weapon-change `svc_weapondata`; `svc_useprint` now carries the touched weapon's name. Every `sv_player` read is gone from client paths (cl_input, input, view, cl_main, cl_hud, gu_draw, gu_QMB, r_screen + nspire/rvl screen copies).
- Client effect timers compared against `sv.time` (always 0 on remote clients): hitmarks, crosshair spread, screenflash, betty prompt, max-ammo banner, recoil decay — now `cl.time`, across all platform draw files.
- `SV_UpdateToReliableMessages` kills-branch updated `old_points` instead of `old_kills` (svc_updatekills re-sent every frame once anyone had a kill).
- HUD: points-counter animation applied to every scoreboard row via shared globals (now local row only); GunGame HUD indexed `svs.maxclients` on the client.
- Precache parsing hardened (bounded copies, `msg_badread` checks).

## Protocol / compatibility

- `PROTOCOL_VERSION` 15 → **16** (svc_clientdata extended; old demos won't play back).
- adhocctl group renamed `"quake"` → `"nzp2"`: v1 dquakeplus shares NET_PROTOCOL_VERSION/PROTOCOL_VERSION but not the svc set, so v1 and 2.x consoles must not discover each other and cross-crash.
- Both peers must run the same build + game data (documented in the menu flow being same-build-only).

## New COOPERATIVE flow (PSP only, `menu_coop.c`)

- **HOST GAME** → map select (existing COOP headers finally reachable) → lobby → `coop 1; maxplayers 4; listen 1; map X`.
- **JOIN GAME** → slist broadcast browser over the host cache → connect by MAC (`cname`), with `m_return_onerror` wiring so failed connects bounce back to the browser with the reason displayed.
- Activation mirrors the proven v1 sequence (`Datagram_Shutdown` → `tcpipAvailable/tcpipAdhoc` → `net_driver_to_use=1` → `Datagram_Init`) with a WLAN-switch check, an on-screen "STARTING ADHOC..." notice and one retry (PPSSPP's built-in server starts alongside the first net init and can race the first join).
- Pause menu now works for connected remote clients (host-only RESTART greyed out); START routes there while connected; `Host_EndGame`/`Host_Error` return a dead remote client to the main menu (deferred to the next frame — the error path can run inside rendering).

## Known limitations / follow-ups

- Song easter-eggs still play host-side only (`PF_SongEgg` uses local `cd playstring`).
- No revive icon above downed teammates on the standard build (prompt + progress bar work; FTE-only broadcast texts are no-ops).
- A joining client has no loading screen during signon (black screen for a few seconds while models load).
- Repeated unattended host game-over/restart cycles eventually left one PPSSPP host instance rendering black in stress testing (rare, non-blocking, under investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)