### PR TITLE
SDL: Statically link SDL2/SDL2_mixer to Windows executable

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -119,19 +119,14 @@ jobs:
         run: |
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           make -f Makefile.sdl WERROR=1 -j$(nproc) \
-            CROSS_COMPILE="${TRIPLET}-"
+            CROSS_COMPILE="${TRIPLET}-" \
             BUILD="build/sdl/${ARCH}" \
-            TARGET="build/sdl/${ARCH}/nzportable.exe"
-      - name: Add DLLs to distributables
-        run: |
-          mkdir -p dist
-          cp build/sdl/nzportable.exe dist/
-          cp /opt/mingw-deps/bin/*.dll dist/
+            TARGET="build/sdl/${ARCH}/nzportable.exe" \
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-${{ matrix.arch }}-nzp-sdl
-          path: dist/
+          path: ./build/sdl/${{ matrix.arch }}/nzportable.exe
   Compile-EBOOT:
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest

--- a/Makefile.sdl
+++ b/Makefile.sdl
@@ -24,7 +24,18 @@ endif
 LDLIBS := $(shell $(PKG_CONFIG) --libs sdl2) -lSDL2_mixer -lm
 TARGET_TRIPLE := $(shell $(CC) -dumpmachine)
 ifneq ($(findstring mingw,$(TARGET_TRIPLE)),)
-LDLIBS += -lopengl32 -lglu32 -lws2_32
+LDLIBS += -static \
+	-lopengl32 \
+	-lglu32 \
+	-lws2_32 \
+	-lsetupapi \
+	-lole32 \
+	-loleaut32 \
+	-limm32 \
+	-lversion \
+	-lcfgmgr32 \
+	-lwinmm \
+	-luuid
 else ifeq ($(shell uname -s),Darwin)
 LDLIBS += -framework OpenGL
 else

--- a/source/platform/sdl/compat_sdl.c
+++ b/source/platform/sdl/compat_sdl.c
@@ -1,5 +1,10 @@
 #include "../../nzportable_def.h"
 
+// when statically linking this on windows,
+// our sdl version already provides this.. so on windows,
+// we can simply ignore this or the compiler blows up, which is fine
+// because functionally it is the same
+#if !defined(_WIN32)
 size_t SDL_strlcpy(char *dst, const char *src, size_t size)
 {
 	size_t length = strlen(src);
@@ -17,3 +22,4 @@ size_t SDL_strlcat(char *dst, const char *src, size_t size)
 	if (used == size) return size + strlen(src);
 	return used + SDL_strlcpy(dst + used, src, size - used);
 }
+#endif

--- a/testing/setup/windows.sh
+++ b/testing/setup/windows.sh
@@ -34,7 +34,6 @@ function obtain_nzportable()
 	fi
 
 	cp "${binary_path}" "${working_dir}/nzportable/${APP_BIN}"
-	cp "$(dirname "${binary_path}")"/*.dll "${working_dir}/nzportable/"
 	chmod +x "${working_dir}/nzportable/${APP_BIN}"
 }
 


### PR DESCRIPTION
### Description of Changes
---
Statically links SDL2 and SDL2_mixer to the Windows executable, eliminating the need for DLLs to be in the ZIP.

### Visual Sample
---
<img width="1392" height="864" alt="image" src="https://github.com/user-attachments/assets/120121ae-4cdc-4f5a-862f-098385c7d1f0" />
(via WINE)

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
