### PR TITLE
GLOBAL: Fix UD in PR_SetString and use permanent storage for useprint strings

### DIFF
--- a/Makefile.sdl
+++ b/Makefile.sdl
@@ -14,7 +14,7 @@ CPPFLAGS := -Isource -I$(BUILD) -DGLQUAKE -DPLATFORM_SDL -DPLATFORM_CONFIRM_IS_E
 			-DMAX_AI_COUNT=24 -DPLATFORM_USES_GENERIC_GLYPHS -DPLATFORM_SUPPORTS_HIGH_FRAMERATES \
 			-DPLATFORM_SUPPORTS_VIDEO_OPTIONS
 CFLAGS ?= -O2 -g
-CFLAGS += -std=gnu99 -Wall -Wno-unused-variable -Wno-unused-but-set-variable $(shell $(PKG_CONFIG) --cflags sdl2 | sed 's/-Dmain=SDL_main//')
+CFLAGS += -std=gnu99 -Wall -fno-strict-aliasing -Wno-unused-variable -Wno-unused-but-set-variable $(shell $(PKG_CONFIG) --cflags sdl2 | sed 's/-Dmain=SDL_main//')
 ifneq ($(findstring clang,$(shell $(CC) --version)),)
 CFLAGS += -Wno-unknown-warning-option -Wno-unknown-pragmas
 endif

--- a/Makefile.sdl
+++ b/Makefile.sdl
@@ -14,7 +14,7 @@ CPPFLAGS := -Isource -I$(BUILD) -DGLQUAKE -DPLATFORM_SDL -DPLATFORM_CONFIRM_IS_E
 			-DMAX_AI_COUNT=24 -DPLATFORM_USES_GENERIC_GLYPHS -DPLATFORM_SUPPORTS_HIGH_FRAMERATES \
 			-DPLATFORM_SUPPORTS_VIDEO_OPTIONS
 CFLAGS ?= -O2 -g
-CFLAGS += -std=gnu99 -Wall -fno-strict-aliasing -Wno-unused-variable -Wno-unused-but-set-variable $(shell $(PKG_CONFIG) --cflags sdl2 | sed 's/-Dmain=SDL_main//')
+CFLAGS += -std=gnu99 -Wall -Wno-unused-variable -Wno-unused-but-set-variable $(shell $(PKG_CONFIG) --cflags sdl2 | sed 's/-Dmain=SDL_main//')
 ifneq ($(findstring clang,$(shell $(CC) --version)),)
 CFLAGS += -Wno-unknown-warning-option -Wno-unknown-pragmas
 endif

--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -1168,6 +1168,7 @@ void CL_ParseServerMessage (void)
 {
 	int			cmd;
 	int			i;
+	int			useprint_cost;
 	int			useprint_index;
 	int			useprint_red, useprint_green, useprint_blue;
 	char		useprint_text[256];
@@ -1248,7 +1249,9 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_useprint:
-			HUD_UsePrint (MSG_ReadByte (), MSG_ReadShort ());
+			useprint_index = MSG_ReadByte ();
+			useprint_cost = MSG_ReadShort ();
+			HUD_UsePrint (useprint_index, useprint_cost);
 			break;
 		case svc_registeruseprint:
 			useprint_index = MSG_ReadByte ();

--- a/source/qcvm/pr_cmds.c
+++ b/source/qcvm/pr_cmds.c
@@ -389,12 +389,20 @@ void PF_useprint (void)
 	MSG_WriteShort (&client->message,cost);
 }
 
-static string_t pr_useprint_strings[256];
+static char *pr_useprint_strings[256];
 static byte pr_useprint_colors[256][3];
 static qboolean pr_useprint_registered[256];
 
 void PR_ClearRegisteredUseprints (void)
 {
+	int index;
+
+	for (index = 0; index < 256; index++)
+	{
+		if (pr_useprint_strings[index])
+			Z_Free (pr_useprint_strings[index]);
+		pr_useprint_strings[index] = NULL;
+	}
 	memset (pr_useprint_registered, 0, sizeof(pr_useprint_registered));
 }
 
@@ -402,7 +410,7 @@ static void PR_WriteUseprintDefinition (client_t *client, int index)
 {
 	MSG_WriteByte (&client->message, svc_registeruseprint);
 	MSG_WriteByte (&client->message, index);
-	MSG_WriteString (&client->message, PR_GetString(pr_useprint_strings[index]));
+	MSG_WriteString (&client->message, pr_useprint_strings[index]);
 	MSG_WriteByte (&client->message, pr_useprint_colors[index][0]);
 	MSG_WriteByte (&client->message, pr_useprint_colors[index][1]);
 	MSG_WriteByte (&client->message, pr_useprint_colors[index][2]);
@@ -420,6 +428,7 @@ void PR_SendRegisteredUseprints (client_t *client)
 void PF_useprint_send (void)
 {
 	client_t *client;
+	char *text, *text_copy;
 	int entnum, index;
 	float *color;
 
@@ -439,7 +448,11 @@ void PF_useprint_send (void)
 	}
 
 	client = &svs.clients[entnum-1];
-	pr_useprint_strings[index] = G_INT(OFS_PARM2);
+	text = G_STRING(OFS_PARM2);
+	text_copy = Z_Strdup(text);
+	if (pr_useprint_strings[index])
+		Z_Free(pr_useprint_strings[index]);
+	pr_useprint_strings[index] = text_copy;
 	pr_useprint_colors[index][0] = CLAMP(0, color[0] * 255, 255);
 	pr_useprint_colors[index][1] = CLAMP(0, color[1] * 255, 255);
 	pr_useprint_colors[index][2] = CLAMP(0, color[2] * 255, 255);

--- a/source/qcvm/pr_edict.c
+++ b/source/qcvm/pr_edict.c
@@ -21,6 +21,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "../nzportable_def.h"
 
+#include <stdint.h>
+
 dprograms_t		*progs;
 dfunction_t		*pr_functions;
 dstatement_t	*pr_statements;
@@ -1520,9 +1522,14 @@ char *PR_GetString(int num)
 
 int PR_SetString(char *s) 
 {
+	uintptr_t address = (uintptr_t)s;
+	uintptr_t strings_address = (uintptr_t)pr_strings;
+	uintptr_t offset;
     int i;
 
-    if (s - pr_strings < 0 || s - pr_strings > pr_strings_size - 2) {
+	if (pr_strings_size < 2
+		|| address < strings_address
+		|| (offset = address - strings_address) > (uintptr_t)(pr_strings_size - 2)) {
         for (i = 0; i < num_prstr; i++)
             if (pr_strtbl[i] == s) break;
         if (i < num_prstr) return -i - 1;
@@ -1534,5 +1541,5 @@ int PR_SetString(char *s)
         num_prstr++;
         return -num_prstr;
     }
-    return (int)(s - pr_strings);
+	return (int)offset;
 }

--- a/source/zone.c
+++ b/source/zone.c
@@ -632,11 +632,12 @@ void *Z_Malloc (int size)
     orig_size -= sizeof(memblock_t);
     orig_size -= sizeof(int); /* ZONEID marker */
 
-    Z_Free(ptr);
     ret = Z_TagMalloc(size, 1);
     if (!ret) Sys_Error("%s: failed on allocation of %i bytes", __func__, size);
-    if (ret != ptr) memmove(ret, ptr, MIN(orig_size, size));
+
+	memcpy(ret, ptr, MIN(orig_size, size));
     if (size > orig_size) memset((byte *)ret + orig_size, 0, size - orig_size);
+	Z_Free(ptr);
     return ret;
 }
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes some undefined behavior with subtracting `pr_strings` that can lead to tempstring corruption, and uses permanent storage instead of `string_t` for useprints to fight against tempstring frees.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
