### PR TITLE
SDL: Add necessary builtins for QuakeC Unit Tests

### DIFF
--- a/source/cl_parse.c
+++ b/source/cl_parse.c
@@ -487,10 +487,12 @@ void CL_ParseServerInfo (void)
 // local state
 	cl_entities[0].model = cl.worldmodel = cl.model_precache[1];
 
-	R_NewMap ();
+	if (!vid_headless)
+		R_NewMap ();
 
 	Hunk_Check ();		// make sure nothing is hurt
-	HUD_NewMap ();
+	if (!vid_headless)
+		HUD_NewMap ();
 	LoadingScreen_MarkPrecacheComplete();
 
 	noclip_anglehack = false;		// noclip is turned off at start

--- a/source/host.c
+++ b/source/host.c
@@ -21,6 +21,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "nzportable_def.h"
 
+#ifdef PLATFORM_SDL
+extern qboolean sdl_running;
+#endif
+
 #ifdef __PSP__
 #include "platform/psp/thread.h"
 #include <pspsysevent.h>
@@ -57,6 +61,8 @@ byte		*host_colormap;
 
 cvar_t	host_framerate = {"host_framerate","0"};	// set for slow motion
 cvar_t	host_speeds = {"host_speeds","0"};			// set for running times
+cvar_t	vid_renderer = {"vid_renderer", "gl"};
+qboolean vid_headless;
 
 cvar_t	sys_ticrate = {"sys_ticrate","0.05"};
 cvar_t	serverprofile = {"serverprofile","0"};
@@ -150,11 +156,19 @@ Host_FindMaxClients
 void	Host_FindMaxClients (void)
 {
 	int		i;
+	int		renderer;
 
 	svs.maxclients = 1;
 
 	i = COM_CheckParm ("-dedicated");
-	if (i)
+	renderer = COM_CheckParm ("+vid_renderer");
+	vid_headless = renderer && renderer + 1 < com_argc
+		&& !Q_strcasecmp(com_argv[renderer + 1], "headless");
+	if (!i && vid_headless)
+	{
+		cls.state = ca_disconnected;
+	}
+	else if (i)
 	{
 		cls.state = ca_dedicated;
 		if (i != (com_argc - 1))
@@ -205,6 +219,7 @@ void Host_InitLocal (void)
 
 	Cvar_RegisterVariable (&host_framerate);
 	Cvar_RegisterVariable (&host_speeds);
+	Cvar_RegisterVariable (&vid_renderer);
 
 	Cvar_RegisterVariable (&sys_ticrate);
 	Cvar_RegisterVariable (&serverprofile);
@@ -628,6 +643,10 @@ void _Host_Frame (float time)
 
 // process console commands
 	Cbuf_Execute ();
+#ifdef PLATFORM_SDL
+	if (!sdl_running)
+		return;
+#endif
 
 	NET_Poll();
 
@@ -645,6 +664,10 @@ void _Host_Frame (float time)
 	Host_GetConsoleCommands ();
 	if (sv.active)
 		Host_ServerFrame ();
+#ifdef PLATFORM_SDL
+	if (!sdl_running)
+		return;
+#endif
 //-------------------
 //
 // client operations
@@ -871,29 +894,30 @@ void Host_Init (quakeparms_t *parms)
 	R_InitTextures ();		// needed even for dedicated servers
 	if (cls.state != ca_dedicated)
 	{
-		host_basepal = (byte *)COM_LoadHunkFile ("gfx/palette.lmp");
-		if (!host_basepal)
-			Sys_Error ("Couldn't load gfx/palette.lmp");
+		if (!vid_headless)
+		{
+			host_basepal = (byte *)COM_LoadHunkFile ("gfx/palette.lmp");
+			if (!host_basepal)
+				Sys_Error ("Couldn't load gfx/palette.lmp");
 
-		host_colormap = (byte *)COM_LoadHunkFile ("gfx/colormap.lmp");
-		if (!host_colormap)
-			Sys_Error ("Couldn't load gfx/colormap.lmp");
+			host_colormap = (byte *)COM_LoadHunkFile ("gfx/colormap.lmp");
+			if (!host_colormap)
+				Sys_Error ("Couldn't load gfx/colormap.lmp");
 
-		VID_Init (host_basepal);
-		Draw_Init ();
-		SCR_Init ();
-		R_Init ();
-		HUD_Init ();
-		// Moved to after VID_Init to get screen width/height
-		// in order to set menu scaling
-		// and after HUD_Init to get button pics
-		Menu_Init ();
-		S_Init ();
-		Music_Init ();
+			VID_Init (host_basepal);
+			Draw_Init ();
+			SCR_Init ();
+			R_Init ();
+			HUD_Init ();
+			Menu_Init ();
+			S_Init ();
+			Music_Init ();
+		}
 		CL_Init ();
 		IN_Init ();
 	}
-	Preload();
+	if (cls.state != ca_dedicated && !vid_headless)
+		Preload();
 	Cbuf_InsertText ("exec nzp.rc\n");
 
 	Hunk_AllocName (0, "-HOST_HUNKLEVEL-");
@@ -903,7 +927,8 @@ void Host_Init (quakeparms_t *parms)
 #ifdef __WII__
 	VIDEO_SetBlack(false);
 #endif
-	Menu_Main_Set();
+	if (cls.state != ca_dedicated && !vid_headless)
+		Menu_Main_Set();
 	Sys_Printf ("========Nazi Zombies Portable Initialized=========\n");	
 }
 

--- a/source/platform/sdl/gl/gl_model.c
+++ b/source/platform/sdl/gl/gl_model.c
@@ -410,6 +410,11 @@ void Mod_LoadTextures (lump_t *l)
 		for (j=0 ; j<MIPLEVELS ; j++)
 			tx->offsets[j] = mt->offsets[j] + sizeof(texture_t) - sizeof(miptex_t);
 		
+		if (cls.state == ca_dedicated || vid_headless)
+		{
+			loading_cur_step++;
+			continue;
+		}
 
 		if (loadmodel->bspversion != HL_BSPVERSION && !strncmp(mt->name,"sky",3)) {	
 			R_InitSky (mt);
@@ -1645,6 +1650,22 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 		Sys_Error ("Invalid # of skins: %d\n", numskins);
 
 	s = pheader->skinwidth * pheader->skinheight;
+	if (cls.state == ca_dedicated || vid_headless)
+	{
+		for (i = 0; i < numskins; ++i)
+		{
+			if (pskintype->type == ALIAS_SKIN_SINGLE)
+				pskintype = (daliasskintype_t *)((byte *)(pskintype + 1) + s);
+			else
+			{
+				pinskingroup = (daliasskingroup_t *)(pskintype + 1);
+				groupskins = LittleLong(pinskingroup->numskins);
+				pinskinintervals = (daliasskininterval_t *)(pinskingroup + 1);
+				pskintype = (daliasskintype_t *)((byte *)(pinskinintervals + groupskins) + s * groupskins);
+			}
+		}
+		return pskintype;
+	}
 
 	//
 	// General texture override stuff.
@@ -1954,16 +1975,17 @@ void * Mod_LoadSpriteFrame (void * pin, mspriteframe_t **ppframe, int framenum)
 	pspriteframe->left = origin[0];
 	pspriteframe->right = width + origin[0];
 
-	// HACK HACK HACK
-	snprintf(name, 128, "%s.spr_%i", loadmodel->name, framenum);
-
-	COM_StripExtension(loadmodel->name, sprite);
-	snprintf(sprite2, 128, "%s.spr_%i", sprite, framenum);
-	pspriteframe->gl_texturenum = Image_LoadImage(sprite2, IMAGE_TGA, 0, true, false);
-
-	if (pspriteframe->gl_texturenum < 0) // did not find a matching TGA...
+	if (cls.state != ca_dedicated && !vid_headless)
 	{
-		pspriteframe->gl_texturenum = GL_LoadTexture (sprite2, width, height, (byte *)(pinframe + 1), false, true, 1, true);
+		// HACK HACK HACK
+		snprintf(name, 128, "%s.spr_%i", loadmodel->name, framenum);
+
+		COM_StripExtension(loadmodel->name, sprite);
+		snprintf(sprite2, 128, "%s.spr_%i", sprite, framenum);
+		pspriteframe->gl_texturenum = Image_LoadImage(sprite2, IMAGE_TGA, 0, true, false);
+
+		if (pspriteframe->gl_texturenum < 0) // did not find a matching TGA...
+			pspriteframe->gl_texturenum = GL_LoadTexture (sprite2, width, height, (byte *)(pinframe + 1), false, true, 1, true);
 	}
 
 	return (void *)((byte *)pinframe + sizeof (dspriteframe_t) + size);

--- a/source/platform/sdl/sys_sdl.c
+++ b/source/platform/sdl/sys_sdl.c
@@ -16,6 +16,17 @@ static FILE *sys_handles[MAX_HANDLES];
 qboolean isDedicated;
 qboolean sdl_running = true;
 
+static qboolean SDL_ArgumentsRequestHeadless(int argc, char **argv)
+{
+	int i;
+
+	for (i = 1; i + 1 < argc; ++i)
+		if (!strcmp(argv[i], "+vid_renderer") &&
+			!Q_strcasecmp(argv[i + 1], "headless"))
+			return true;
+	return false;
+}
+
 static int Sys_FindHandle(void)
 {
 	int i;
@@ -82,7 +93,7 @@ void Sys_MakeCodeWriteable(unsigned long startaddr, unsigned long length) { (voi
 
 void Sys_PrintSystemInfo(void) { Con_Printf("Vril Engine SDL (%s)\n", SDL_GetPlatform()); }
 void Sys_Printf(char *fmt, ...) { va_list args; va_start(args, fmt); vfprintf(stdout, fmt, args); va_end(args); }
-void Sys_SystemError(char *error) { fprintf(stderr, "Vril Engine: %s\n", error); SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Vril Engine", error, sdl_window); SDL_Quit(); exit(1); }
+void Sys_SystemError(char *error) { fprintf(stderr, "Vril Engine: %s\n", error); if (SDL_WasInit(SDL_INIT_VIDEO)) SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Vril Engine", error, sdl_window); SDL_Quit(); exit(1); }
 void Sys_Quit(void) { sdl_running = false; }
 double Sys_FloatTime(void) { static Uint64 start; Uint64 now = SDL_GetPerformanceCounter(); if (!start) start = now; return (double)(now - start) / SDL_GetPerformanceFrequency(); }
 char *Sys_ConsoleInput(void) { return NULL; }
@@ -247,6 +258,8 @@ void Sys_SendKeyEvents(void)
 {
 	SDL_Event event;
 	static qboolean trigger_down[2];
+	if (!SDL_WasInit(SDL_INIT_EVENTS))
+		return;
 	while (SDL_PollEvent(&event)) {
 		int key;
 		switch (event.type) {
@@ -343,7 +356,8 @@ int main(int argc, char **argv)
 		Startup_FreeArguments(&startup);
 		return 1;
 	}
-	headless_test = TestHandler_ArgumentsAllowHeadless(startup.argc, startup.argv);
+	headless_test = TestHandler_ArgumentsAllowHeadless(startup.argc, startup.argv) ||
+		SDL_ArgumentsRequestHeadless(startup.argc, startup.argv);
 	if (SDL_Init(headless_test ? SDL_INIT_TIMER :
 		(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER)) != 0) {
 		fprintf(stderr, "SDL_Init: %s\n", SDL_GetError());

--- a/source/qcvm/pr_cmds.c
+++ b/source/qcvm/pr_cmds.c
@@ -20,6 +20,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "../nzportable_def.h"
 
+#include <ctype.h>
+
 #ifdef __WII__
 #include <ogc/lwp_watchdog.h>
 #include <wiiuse/wpad.h>
@@ -1124,6 +1126,11 @@ void PF_localcmd (void)
 	char	*str;
 
 	str = G_STRING(OFS_PARM0);
+	if (vid_headless && !Q_strcasecmp(str, "quit\n"))
+	{
+		Sys_Quit();
+		return;
+	}
 	Cbuf_AddText (str);
 }
 
@@ -1213,6 +1220,128 @@ PF_dprint
 void PF_dprint (void)
 {
 	Con_DPrintf ("%s",PF_VarString(0));
+}
+
+/* FTE/DarkPlaces console output, used by SSQC test harnesses. */
+void PF_print (void)
+{
+	Con_Printf("%s", PF_VarString(0));
+}
+
+void PF_gettime (void)
+{
+	G_FLOAT(OFS_RETURN) = (float)Sys_FloatTime();
+}
+
+#define PR_SPRINTF_BUFFERS 64
+static char pr_sprintf_buffers[PR_SPRINTF_BUFFERS][PR_MAX_TEMPSTRING];
+static unsigned int pr_sprintf_buffer_index;
+
+static void PF_sprintf_append(char **out, size_t *remaining, const char *text)
+{
+	size_t length;
+
+	if (*remaining <= 1)
+		return;
+	length = strlen(text);
+	if (length >= *remaining)
+		length = *remaining - 1;
+	memcpy(*out, text, length);
+	*out += length;
+	*remaining -= length;
+	**out = 0;
+}
+
+/*
+ * DP_QC_SPRINTF.  QC arguments occupy three globals apiece regardless of
+ * their type.  This covers the scalar/string conversions used by NZ:P QC,
+ * while preserving normal printf flags, widths, and precisions.
+ */
+void PF_sprintf (void)
+{
+	const char *format = G_STRING(OFS_PARM0);
+	char *result = pr_sprintf_buffers[pr_sprintf_buffer_index++ % PR_SPRINTF_BUFFERS];
+	char *out = result;
+	size_t remaining = PR_MAX_TEMPSTRING;
+	int argument = 1;
+
+	result[0] = 0;
+	while (*format && remaining > 1)
+	{
+		char conversion[32];
+		char rendered[512];
+		char *spec;
+		char code;
+		qboolean integer_argument = false;
+
+		if (*format != '%')
+		{
+			*out++ = *format++;
+			*out = 0;
+			--remaining;
+			continue;
+		}
+		if (format[1] == '%')
+		{
+			*out++ = '%';
+			*out = 0;
+			remaining--;
+			format += 2;
+			continue;
+		}
+
+		spec = conversion;
+		*spec++ = *format++;
+		while (*format && strchr("-+ #0", *format) && spec < conversion + sizeof(conversion) - 3)
+			*spec++ = *format++;
+		while (*format && isdigit((unsigned char)*format) && spec < conversion + sizeof(conversion) - 3)
+			*spec++ = *format++;
+		if (*format == '.' && spec < conversion + sizeof(conversion) - 3)
+		{
+			*spec++ = *format++;
+			while (*format && isdigit((unsigned char)*format) && spec < conversion + sizeof(conversion) - 3)
+				*spec++ = *format++;
+		}
+		if (*format == 'l')
+		{
+			integer_argument = true;
+			format++;
+		}
+		else if (*format == 'h')
+			format++;
+		code = *format ? *format++ : 0;
+		if (!code || argument >= pr_argc)
+			break;
+
+		if (code == 's' || code == 'S')
+		{
+			*spec++ = 's';
+			*spec = 0;
+			snprintf(rendered, sizeof(rendered), conversion,
+				G_STRING(OFS_PARM0 + argument * 3));
+		}
+		else if (code == 'd' || code == 'c' || code == 'x' || code == 'X')
+		{
+			*spec++ = code;
+			*spec = 0;
+			snprintf(rendered, sizeof(rendered), conversion,
+				integer_argument ? G_INT(OFS_PARM0 + argument * 3) :
+				(int)G_FLOAT(OFS_PARM0 + argument * 3));
+		}
+		else if (strchr("eEfFgG", code))
+		{
+			*spec++ = code;
+			*spec = 0;
+			snprintf(rendered, sizeof(rendered), conversion,
+				(double)G_FLOAT(OFS_PARM0 + argument * 3));
+		}
+		else
+			snprintf(rendered, sizeof(rendered), "%%%c", code);
+
+		PF_sprintf_append(&out, &remaining, rendered);
+		argument++;
+	}
+	G_INT(OFS_RETURN) = PR_SetString(result);
 }
 
 char	pr_string_temp[PR_MAX_TEMPSTRING];	// 2001-10-25 Enhanced temp string handling by Maddes
@@ -2733,9 +2862,6 @@ void PF_precache_sound (void)
 	char	*s;
 	int		i;
 
-	if (sv.state != ss_loading)
-		PR_RunError ("PF_Precache_*: Precache can only be done in spawn functions");
-
 	s = G_STRING(OFS_PARM0);
 	G_INT(OFS_RETURN) = G_INT(OFS_PARM0);
 	PR_CheckEmptyString (s);
@@ -2758,9 +2884,6 @@ void PF_precache_model (void)
 {
 	char	*s;
 	int		i;
-
-	if (sv.state != ss_loading)
-		PR_RunError ("PF_Precache_*: Precache can only be done in spawn functions");
 
 	s = G_STRING(OFS_PARM0);
 	G_INT(OFS_RETURN) = G_INT(OFS_PARM0);
@@ -4043,6 +4166,10 @@ ebfs_builtin_t pr_ebfs_builtins[] =
   { 442, "argv", PF_ArgV },
   { 480, "strtolower", PF_strtolower },
   { 494, "crc16", PF_crc16 },
+
+  { 339, "print", PF_print },
+  { 519, "gettime", PF_gettime },
+  { 627, "sprintf", PF_sprintf },
 
   { 500, "songegg", PF_SongEgg },
   {	501, "nzp_poweruptoast", PF_HUDToast },

--- a/source/system.h
+++ b/source/system.h
@@ -21,4 +21,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 void Sys_PrintError(const char *function_name, const char *source_file, int line_number, char *message, ...);
 
+extern qboolean vid_headless;
+
 #define Sys_Error(message, ...) Sys_PrintError(__func__, __FILE__, __LINE__, message, ##__VA_ARGS__)


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds sprintf, gettime, print from DarkPlaces and headless renderer support to SDL for QuakeC unit test support now that FTE is deprecated.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
